### PR TITLE
RichText to Portable Text data and schema transformations. Fixes #7

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
     "node": ">=7.6.0"
   },
   "scripts": {
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "jest"
   },
   "repository": {
     "type": "git",
@@ -30,7 +30,8 @@
   "devDependencies": {
     "eslint": "^4.7.2",
     "eslint-config-prettier": "^2.5.0",
-    "eslint-config-sanity": "^3.0.1"
+    "eslint-config-sanity": "^3.0.1",
+    "jest": "^26.0.1"
   },
   "dependencies": {
     "@sanity/block-tools": "0.133.2",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@sanity/schema": "0.133.2",
     "configstore": "^4.0.0",
     "contentful-batch-libs": "5.10.0",
+    "contentful-rich-text-to-portable-text": "0.1.0",
     "execa": "^0.8.0",
     "fs-extra": "^4.0.3",
     "hard-rejection": "^1.0.0",

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,0 +1,6 @@
+module.exports = {
+  trailingComma: 'es5',
+  tabWidth: 2,
+  semi: false,
+  singleQuote: true,
+}

--- a/prettier.config.js
+++ b/prettier.config.js
@@ -1,6 +1,7 @@
 module.exports = {
-  trailingComma: 'es5',
+  trailingComma: 'none',
+  bracketSpacing: false,
   tabWidth: 2,
   semi: false,
-  singleQuote: true,
+  singleQuote: true
 }

--- a/src/builtinTypes.js
+++ b/src/builtinTypes.js
@@ -1,0 +1,22 @@
+const builtins = [
+  {
+    name: "break",
+    type: "object",
+    title: "Break",
+    fields: [
+      {
+        name: "style",
+        type: "string",
+        title: "Break style",
+        options: {
+          list: [
+            { title: "Line break", value: "lineBreak" },
+            { title: "Read more", value: "readMore" },
+          ],
+        },
+      },
+    ],
+  },
+];
+
+module.exports = builtins;

--- a/src/transformData.js
+++ b/src/transformData.js
@@ -1,6 +1,6 @@
 const crypto = require('crypto')
 const markdownToBlocks = require('./markdownToBlocks')
-const { toPortableText } = require('contentful-rich-text-to-portable-text')
+const {toPortableText} = require('contentful-rich-text-to-portable-text')
 
 const transformData = (data, options = {}) => {
   if (data.locales.length > 1 && !options.locale) {
@@ -19,7 +19,7 @@ const transformData = (data, options = {}) => {
   }
 
   const locale = options.locale || data.locales[0].code
-  const opts = Object.assign({}, options, { locale })
+  const opts = Object.assign({}, options, {locale})
   return data.entries
     .filter(isPublished)
     .map(entry => transformEntry(entry, data, opts))
@@ -34,7 +34,7 @@ function transformEntry(entry, data, options) {
     _id: entry.sys.id,
     _type: entry.sys.contentType.sys.id,
     _createdAt: entry.sys.createdAt,
-    _updatedAt: entry.sys.updatedAt,
+    _updatedAt: entry.sys.updatedAt
   }
 
   return Object.keys(entry.fields).reduce((acc, fieldName) => {
@@ -44,7 +44,7 @@ function transformEntry(entry, data, options) {
 }
 
 function transformField(entry, fieldName, data, options) {
-  const { locale, keepMarkdown } = options
+  const {locale, keepMarkdown} = options
   const value = entry.fields[fieldName][locale]
   const typeId = entry.sys.contentType.sys.id
   const editor = data.editorInterfaces.find(
@@ -62,7 +62,7 @@ function transformField(entry, fieldName, data, options) {
   }
 
   if (value && widgetId === 'slugEditor') {
-    return { current: value }
+    return {current: value}
   }
 
   if (value && value.sys && value.sys.type === 'Link') {
@@ -106,12 +106,12 @@ function transformLocation(coords) {
   return {
     _type: 'geopoint',
     lat: coords.lat,
-    lng: coords.lon,
+    lng: coords.lon
   }
 }
 
 function maybeWeakRef(ref, options) {
-  return options.weakRefs ? Object.assign({}, ref, { _weak: true }) : ref
+  return options.weakRefs ? Object.assign({}, ref, {_weak: true}) : ref
 }
 
 function transformLink(value, data, locale, options, parent) {
@@ -120,7 +120,7 @@ function transformLink(value, data, locale, options, parent) {
   }
 
   if (value.sys.linkType === 'Entry') {
-    return maybeWeakRef({ _type: 'reference', _ref: value.sys.id }, options)
+    return maybeWeakRef({_type: 'reference', _ref: value.sys.id}, options)
   }
 
   throw new Error(`Unhandled link type "${value.sys.linkType}"`)
@@ -140,7 +140,7 @@ function transformAssetLink(value, data, locale, options, parent) {
   const file = asset.fields.file[locale]
   const type = file.contentType.startsWith('image/') ? 'image' : 'file'
   return maybeWeakRef(
-    { _type: 'reference', _sanityAsset: `${type}@${prefixUrl(file.url)}` },
+    {_type: 'reference', _sanityAsset: `${type}@${prefixUrl(file.url)}`},
     options
   )
 }
@@ -165,11 +165,11 @@ function transformRichText(data, options) {
           {
             _type: 'break',
             _key: generateKey(),
-            style: 'lineBreak',
-          },
+            style: 'lineBreak'
+          }
         ]
-      },
-    },
+      }
+    }
   })
 }
 

--- a/src/transformData.js
+++ b/src/transformData.js
@@ -160,13 +160,13 @@ function generateKey(length = 8) {
 
 function transformRichText(data, options) {
   return toPortableText(data, {
-    generateKey: () => generateKey(8),
+    generateKey: () => generateKey(),
     transformers: {
       hr: () => {
         return [
           {
             _type: "break",
-            _key: generateKey(8),
+            _key: generateKey(),
             style: "lineBreak",
           },
         ];

--- a/src/transformData.js
+++ b/src/transformData.js
@@ -82,7 +82,7 @@ function transformField(entry, fieldName, data, options) {
   }
 
   if (typeDef.type === 'RichText') {
-    return transformRichText(value, {})
+    return transformRichText(value, data, locale, options)
   }
 
   if (typeDef.type === 'Location') {
@@ -156,10 +156,20 @@ function generateKey(length = 8) {
   return alphaNum.slice(0, length)
 }
 
-function transformRichText(data, options) {
-  return toPortableText(data, {
+function transformRichText(value, data, locale, options) {
+  return toPortableText(value, {
     generateKey: () => generateKey(),
     transformers: {
+      'embedded-asset-block': node => {
+        return [
+          Object.assign(
+            transformAssetLink(node.data.target, data, locale, options),
+            {
+              _key: generateKey()
+            }
+          )
+        ]
+      },
       hr: () => {
         return [
           {

--- a/src/transformData.js
+++ b/src/transformData.js
@@ -1,21 +1,32 @@
-const markdownToBlocks = require('./markdownToBlocks')
+const crypto = require("crypto");
+const markdownToBlocks = require("./markdownToBlocks");
+const { toPortableText } = require("contentful-rich-text-to-portable-text");
 
 const transformData = (data, options = {}) => {
   if (data.locales.length > 1 && !options.locale) {
-    throw new Error('Only one locale supported currently, please specify which locale to use')
+    throw new Error(
+      "Only one locale supported currently, please specify which locale to use"
+    );
   }
 
-  if (options.locale && !data.locales.find(locale => locale.code === options.locale)) {
-    throw new Error(`Locale "${options.locale}" not found in exported Contentful data`)
+  if (
+    options.locale &&
+    !data.locales.find((locale) => locale.code === options.locale)
+  ) {
+    throw new Error(
+      `Locale "${options.locale}" not found in exported Contentful data`
+    );
   }
 
-  const locale = options.locale || data.locales[0].code
-  const opts = Object.assign({}, options, {locale})
-  return data.entries.filter(isPublished).map(entry => transformEntry(entry, data, opts))
-}
+  const locale = options.locale || data.locales[0].code;
+  const opts = Object.assign({}, options, { locale });
+  return data.entries
+    .filter(isPublished)
+    .map((entry) => transformEntry(entry, data, opts));
+};
 
 function isPublished(entry) {
-  return typeof entry.sys.publishedAt === 'string'
+  return typeof entry.sys.publishedAt === "string";
 }
 
 function transformEntry(entry, data, options) {
@@ -23,110 +34,145 @@ function transformEntry(entry, data, options) {
     _id: entry.sys.id,
     _type: entry.sys.contentType.sys.id,
     _createdAt: entry.sys.createdAt,
-    _updatedAt: entry.sys.updatedAt
-  }
+    _updatedAt: entry.sys.updatedAt,
+  };
 
   return Object.keys(entry.fields).reduce((acc, fieldName) => {
-    acc[fieldName] = transformField(entry, fieldName, data, options)
-    return acc
-  }, doc)
+    acc[fieldName] = transformField(entry, fieldName, data, options);
+    return acc;
+  }, doc);
 }
 
 function transformField(entry, fieldName, data, options) {
-  const {locale, keepMarkdown} = options
-  const value = entry.fields[fieldName][locale]
-  const typeId = entry.sys.contentType.sys.id
-  const editor = data.editorInterfaces.find(ed => ed.sys.contentType.sys.id === typeId)
-  const widgetId = editor.controls.find(ctrl => ctrl.fieldId === fieldName).widgetId
+  const { locale, keepMarkdown } = options;
+  const value = entry.fields[fieldName][locale];
+  const typeId = entry.sys.contentType.sys.id;
+  const editor = data.editorInterfaces.find(
+    (ed) => ed.sys.contentType.sys.id === typeId
+  );
+  const widgetId = editor.controls.find((ctrl) => ctrl.fieldId === fieldName)
+    .widgetId;
 
-  if (typeof value === 'undefined') {
-    return undefined
+  if (typeof value === "undefined") {
+    return undefined;
   }
 
-  if (!keepMarkdown && typeof value === 'string' && widgetId === 'markdown') {
-    return markdownToBlocks(value, options)
+  if (!keepMarkdown && typeof value === "string" && widgetId === "markdown") {
+    return markdownToBlocks(value, options);
   }
 
-  if (value && widgetId === 'slugEditor') {
-    return {current: value}
+  if (value && widgetId === "slugEditor") {
+    return { current: value };
   }
 
-  if (value && value.sys && value.sys.type === 'Link') {
-    return transformLink(value, data, locale, options, entry)
+  if (value && value.sys && value.sys.type === "Link") {
+    return transformLink(value, data, locale, options, entry);
   }
 
-  const parentTypeDef = data.contentTypes.find(type => type.sys.id === typeId)
+  const parentTypeDef = data.contentTypes.find(
+    (type) => type.sys.id === typeId
+  );
   if (!parentTypeDef) {
-    throw new Error(`Could not find type definition for type "${typeId}"`)
+    throw new Error(`Could not find type definition for type "${typeId}"`);
   }
 
-  const typeDef = parentTypeDef.fields.find(field => field.id === fieldName)
+  const typeDef = parentTypeDef.fields.find((field) => field.id === fieldName);
   if (!typeDef) {
-    throw new Error(`Could not find type definition for field "${fieldName}" in type "${typeId}"`)
+    throw new Error(
+      `Could not find type definition for field "${fieldName}" in type "${typeId}"`
+    );
   }
 
-  if (typeDef.type === 'Location') {
-    return transformLocation(value)
+  if (typeDef.type === "RichText") {
+    return transformRichText(value, {});
+  }
+
+  if (typeDef.type === "Location") {
+    return transformLocation(value);
   }
 
   if (Array.isArray(value)) {
-    return value.map(val => {
-      if (val && val.sys && val.sys.type === 'Link') {
-        return transformLink(val, data, locale, options, entry)
+    return value.map((val) => {
+      if (val && val.sys && val.sys.type === "Link") {
+        return transformLink(val, data, locale, options, entry);
       }
 
-      return val
-    })
+      return val;
+    });
   }
 
-  return value
+  return value;
 }
 
 function transformLocation(coords) {
   return {
-    _type: 'geopoint',
+    _type: "geopoint",
     lat: coords.lat,
-    lng: coords.lon
-  }
+    lng: coords.lon,
+  };
 }
 
 function maybeWeakRef(ref, options) {
-  return options.weakRefs ? Object.assign({}, ref, {_weak: true}) : ref
+  return options.weakRefs ? Object.assign({}, ref, { _weak: true }) : ref;
 }
 
 function transformLink(value, data, locale, options, parent) {
-  if (value.sys.linkType === 'Asset') {
-    return transformAssetLink(value, data, locale, options, parent)
+  if (value.sys.linkType === "Asset") {
+    return transformAssetLink(value, data, locale, options, parent);
   }
 
-  if (value.sys.linkType === 'Entry') {
-    return maybeWeakRef({_type: 'reference', _ref: value.sys.id}, options)
+  if (value.sys.linkType === "Entry") {
+    return maybeWeakRef({ _type: "reference", _ref: value.sys.id }, options);
   }
 
-  throw new Error(`Unhandled link type "${value.sys.linkType}"`)
+  throw new Error(`Unhandled link type "${value.sys.linkType}"`);
 }
 
 function transformAssetLink(value, data, locale, options, parent) {
-  const asset = data.assets.find(item => item.sys.id === value.sys.id)
+  const asset = data.assets.find((item) => item.sys.id === value.sys.id);
   if (!asset && !options.weakRefs) {
-    const parentId = parent.sys.id
+    const parentId = parent.sys.id;
     throw new Error(
       `Document with ID "${parentId}" references non-existing asset with ID "${value.sys.id}"`
-    )
+    );
   } else if (!asset) {
-    return undefined
+    return undefined;
   }
 
-  const file = asset.fields.file[locale]
-  const type = file.contentType.startsWith('image/') ? 'image' : 'file'
+  const file = asset.fields.file[locale];
+  const type = file.contentType.startsWith("image/") ? "image" : "file";
   return maybeWeakRef(
-    {_type: 'reference', _sanityAsset: `${type}@${prefixUrl(file.url)}`},
+    { _type: "reference", _sanityAsset: `${type}@${prefixUrl(file.url)}` },
     options
-  )
+  );
 }
 
 function prefixUrl(url) {
-  return url.startsWith('//') ? `https:${url}` : url
+  return url.startsWith("//") ? `https:${url}` : url;
 }
 
-module.exports = transformData
+function generateKey(length = 8) {
+  const bytes = crypto.randomBytes(length * 2);
+  const base64 = bytes.toString("base64");
+  const alphaNum = base64.replace(/[^a-z0-9]/gi, "");
+  return alphaNum.slice(0, length);
+}
+
+function transformRichText(data, options) {
+  return toPortableText(data, {
+    generateKey: () => generateKey(8),
+    transformers: {
+      hr: () => {
+        return [
+          {
+            _type: "break",
+            _key: generateKey(8),
+            style: "lineBreak",
+          },
+        ];
+      },
+    },
+  });
+}
+
+module.exports = transformData;

--- a/src/transformData.js
+++ b/src/transformData.js
@@ -1,32 +1,32 @@
-const crypto = require("crypto");
-const markdownToBlocks = require("./markdownToBlocks");
-const { toPortableText } = require("contentful-rich-text-to-portable-text");
+const crypto = require('crypto')
+const markdownToBlocks = require('./markdownToBlocks')
+const { toPortableText } = require('contentful-rich-text-to-portable-text')
 
 const transformData = (data, options = {}) => {
   if (data.locales.length > 1 && !options.locale) {
     throw new Error(
-      "Only one locale supported currently, please specify which locale to use"
-    );
+      'Only one locale supported currently, please specify which locale to use'
+    )
   }
 
   if (
     options.locale &&
-    !data.locales.find((locale) => locale.code === options.locale)
+    !data.locales.find(locale => locale.code === options.locale)
   ) {
     throw new Error(
       `Locale "${options.locale}" not found in exported Contentful data`
-    );
+    )
   }
 
-  const locale = options.locale || data.locales[0].code;
-  const opts = Object.assign({}, options, { locale });
+  const locale = options.locale || data.locales[0].code
+  const opts = Object.assign({}, options, { locale })
   return data.entries
     .filter(isPublished)
-    .map((entry) => transformEntry(entry, data, opts));
-};
+    .map(entry => transformEntry(entry, data, opts))
+}
 
 function isPublished(entry) {
-  return typeof entry.sys.publishedAt === "string";
+  return typeof entry.sys.publishedAt === 'string'
 }
 
 function transformEntry(entry, data, options) {
@@ -35,127 +35,125 @@ function transformEntry(entry, data, options) {
     _type: entry.sys.contentType.sys.id,
     _createdAt: entry.sys.createdAt,
     _updatedAt: entry.sys.updatedAt,
-  };
+  }
 
   return Object.keys(entry.fields).reduce((acc, fieldName) => {
-    acc[fieldName] = transformField(entry, fieldName, data, options);
-    return acc;
-  }, doc);
+    acc[fieldName] = transformField(entry, fieldName, data, options)
+    return acc
+  }, doc)
 }
 
 function transformField(entry, fieldName, data, options) {
-  const { locale, keepMarkdown } = options;
-  const value = entry.fields[fieldName][locale];
-  const typeId = entry.sys.contentType.sys.id;
+  const { locale, keepMarkdown } = options
+  const value = entry.fields[fieldName][locale]
+  const typeId = entry.sys.contentType.sys.id
   const editor = data.editorInterfaces.find(
-    (ed) => ed.sys.contentType.sys.id === typeId
-  );
-  const widgetId = editor.controls.find((ctrl) => ctrl.fieldId === fieldName)
-    .widgetId;
+    ed => ed.sys.contentType.sys.id === typeId
+  )
+  const widgetId = editor.controls.find(ctrl => ctrl.fieldId === fieldName)
+    .widgetId
 
-  if (typeof value === "undefined") {
-    return undefined;
+  if (typeof value === 'undefined') {
+    return undefined
   }
 
-  if (!keepMarkdown && typeof value === "string" && widgetId === "markdown") {
-    return markdownToBlocks(value, options);
+  if (!keepMarkdown && typeof value === 'string' && widgetId === 'markdown') {
+    return markdownToBlocks(value, options)
   }
 
-  if (value && widgetId === "slugEditor") {
-    return { current: value };
+  if (value && widgetId === 'slugEditor') {
+    return { current: value }
   }
 
-  if (value && value.sys && value.sys.type === "Link") {
-    return transformLink(value, data, locale, options, entry);
+  if (value && value.sys && value.sys.type === 'Link') {
+    return transformLink(value, data, locale, options, entry)
   }
 
-  const parentTypeDef = data.contentTypes.find(
-    (type) => type.sys.id === typeId
-  );
+  const parentTypeDef = data.contentTypes.find(type => type.sys.id === typeId)
   if (!parentTypeDef) {
-    throw new Error(`Could not find type definition for type "${typeId}"`);
+    throw new Error(`Could not find type definition for type "${typeId}"`)
   }
 
-  const typeDef = parentTypeDef.fields.find((field) => field.id === fieldName);
+  const typeDef = parentTypeDef.fields.find(field => field.id === fieldName)
   if (!typeDef) {
     throw new Error(
       `Could not find type definition for field "${fieldName}" in type "${typeId}"`
-    );
+    )
   }
 
-  if (typeDef.type === "RichText") {
-    return transformRichText(value, {});
+  if (typeDef.type === 'RichText') {
+    return transformRichText(value, {})
   }
 
-  if (typeDef.type === "Location") {
-    return transformLocation(value);
+  if (typeDef.type === 'Location') {
+    return transformLocation(value)
   }
 
   if (Array.isArray(value)) {
-    return value.map((val) => {
-      if (val && val.sys && val.sys.type === "Link") {
-        return transformLink(val, data, locale, options, entry);
+    return value.map(val => {
+      if (val && val.sys && val.sys.type === 'Link') {
+        return transformLink(val, data, locale, options, entry)
       }
 
-      return val;
-    });
+      return val
+    })
   }
 
-  return value;
+  return value
 }
 
 function transformLocation(coords) {
   return {
-    _type: "geopoint",
+    _type: 'geopoint',
     lat: coords.lat,
     lng: coords.lon,
-  };
+  }
 }
 
 function maybeWeakRef(ref, options) {
-  return options.weakRefs ? Object.assign({}, ref, { _weak: true }) : ref;
+  return options.weakRefs ? Object.assign({}, ref, { _weak: true }) : ref
 }
 
 function transformLink(value, data, locale, options, parent) {
-  if (value.sys.linkType === "Asset") {
-    return transformAssetLink(value, data, locale, options, parent);
+  if (value.sys.linkType === 'Asset') {
+    return transformAssetLink(value, data, locale, options, parent)
   }
 
-  if (value.sys.linkType === "Entry") {
-    return maybeWeakRef({ _type: "reference", _ref: value.sys.id }, options);
+  if (value.sys.linkType === 'Entry') {
+    return maybeWeakRef({ _type: 'reference', _ref: value.sys.id }, options)
   }
 
-  throw new Error(`Unhandled link type "${value.sys.linkType}"`);
+  throw new Error(`Unhandled link type "${value.sys.linkType}"`)
 }
 
 function transformAssetLink(value, data, locale, options, parent) {
-  const asset = data.assets.find((item) => item.sys.id === value.sys.id);
+  const asset = data.assets.find(item => item.sys.id === value.sys.id)
   if (!asset && !options.weakRefs) {
-    const parentId = parent.sys.id;
+    const parentId = parent.sys.id
     throw new Error(
       `Document with ID "${parentId}" references non-existing asset with ID "${value.sys.id}"`
-    );
+    )
   } else if (!asset) {
-    return undefined;
+    return undefined
   }
 
-  const file = asset.fields.file[locale];
-  const type = file.contentType.startsWith("image/") ? "image" : "file";
+  const file = asset.fields.file[locale]
+  const type = file.contentType.startsWith('image/') ? 'image' : 'file'
   return maybeWeakRef(
-    { _type: "reference", _sanityAsset: `${type}@${prefixUrl(file.url)}` },
+    { _type: 'reference', _sanityAsset: `${type}@${prefixUrl(file.url)}` },
     options
-  );
+  )
 }
 
 function prefixUrl(url) {
-  return url.startsWith("//") ? `https:${url}` : url;
+  return url.startsWith('//') ? `https:${url}` : url
 }
 
 function generateKey(length = 8) {
-  const bytes = crypto.randomBytes(length * 2);
-  const base64 = bytes.toString("base64");
-  const alphaNum = base64.replace(/[^a-z0-9]/gi, "");
-  return alphaNum.slice(0, length);
+  const bytes = crypto.randomBytes(length * 2)
+  const base64 = bytes.toString('base64')
+  const alphaNum = base64.replace(/[^a-z0-9]/gi, '')
+  return alphaNum.slice(0, length)
 }
 
 function transformRichText(data, options) {
@@ -165,14 +163,14 @@ function transformRichText(data, options) {
       hr: () => {
         return [
           {
-            _type: "break",
+            _type: 'break',
             _key: generateKey(),
-            style: "lineBreak",
+            style: 'lineBreak',
           },
-        ];
+        ]
       },
     },
-  });
+  })
 }
 
-module.exports = transformData;
+module.exports = transformData

--- a/src/transformSchema.js
+++ b/src/transformSchema.js
@@ -1,31 +1,60 @@
+const builtIns = require("./builtinTypes");
+
 const directMap = {
-  Integer: 'number',
-  Number: 'number',
-  Symbol: 'string',
-  Location: 'geopoint',
-  Boolean: 'boolean',
-  Date: 'datetime',
-  Object: 'object'
-}
+  Integer: "number",
+  Number: "number",
+  Symbol: "string",
+  Location: "geopoint",
+  Boolean: "boolean",
+  Date: "datetime",
+  Object: "object",
+};
 
 const defaultEditors = {
-  Integer: 'numberEditor',
-  Number: 'numberEditor',
-  Symbol: 'singleLine',
-  Location: 'locationEditor',
-  Boolean: 'boolean',
-  Date: 'datePicker',
-  Object: 'objectEditor'
-}
+  Integer: "numberEditor",
+  Number: "numberEditor",
+  Symbol: "singleLine",
+  Location: "locationEditor",
+  Boolean: "boolean",
+  Date: "datePicker",
+  Object: "objectEditor",
+};
 
 const editorMap = {
-  radio: 'radio',
-  dropdown: 'dropdown',
-  tagEditor: 'tags'
+  radio: "radio",
+  dropdown: "dropdown",
+  tagEditor: "tags",
+};
+
+function portableTextType(contentTypes) {
+  const docReferences = contentTypes
+    .filter((typeDef) => {
+      return typeDef.type === "document";
+    })
+    .map((doc) => ({
+      type: "reference",
+      name: `${doc.name}Ref`,
+      to: [{ type: doc.name }],
+    }));
+
+  return {
+    name: "portableText",
+    type: "array",
+    title: "Rich text",
+    of: [
+      { type: "block", of: [{ type: "image" }].concat(docReferences) },
+      { type: "break" },
+      { type: "image" },
+    ].concat(docReferences),
+  };
 }
 
 function transformSchema(data, options) {
-  return data.contentTypes.map(type => transformContentType(type, data, options))
+  const contentTypes = data.contentTypes.map((type) =>
+    transformContentType(type, data, options)
+  );
+
+  return builtIns.concat(portableTextType(contentTypes)).concat(contentTypes);
 }
 
 function transformContentType(type, data, options) {
@@ -33,185 +62,212 @@ function transformContentType(type, data, options) {
     name: type.sys.id,
     title: type.name,
     description: type.description || undefined,
-    type: 'document'
-  }
+    type: "document",
+  };
 
   if (type.displayField) {
-    output.preview = {select: {title: type.displayField}}
+    output.preview = { select: { title: type.displayField } };
   }
 
   output.fields = type.fields
-    .filter(field => !field.omitted)
-    .filter(field => !shouldSkip(field, data, type.sys.id))
-    .map(source =>
+    .filter((field) => !field.omitted)
+    .filter((field) => !shouldSkip(field, data, type.sys.id))
+    .map((source) =>
       Object.assign(
         {
           name: source.id,
-          title: source.name
+          title: source.name,
         },
         isRequired(source),
         isHidden(source),
-        {type: undefined},
+        { type: undefined },
         contentfulTypeToSanityType(source, data, type.sys.id, options)
       )
-    )
+    );
 
-  return output
+  return output;
 }
 
 function isHidden(field) {
-  return field.disabled ? {hidden: true} : {}
+  return field.disabled ? { hidden: true } : {};
 }
 
 function isRequired(field) {
-  return field.required ? {required: true} : {}
+  return field.required ? { required: true } : {};
 }
 
 function shouldSkip(source, data, typeId) {
-  const editor = data.editorInterfaces.find(ed => ed.sys.contentType.sys.id === typeId)
-  const widgetId = editor.controls.find(ctrl => ctrl.fieldId === source.id).widgetId
-  return source.type === 'Object' && widgetId === 'objectEditor'
+  const editor = data.editorInterfaces.find(
+    (ed) => ed.sys.contentType.sys.id === typeId
+  );
+  const widgetId = editor.controls.find((ctrl) => ctrl.fieldId === source.id)
+    .widgetId;
+  return source.type === "Object" && widgetId === "objectEditor";
 }
 
 function contentfulTypeToSanityType(source, data, typeId, options) {
-  const editor = data.editorInterfaces.find(ed => ed.sys.contentType.sys.id === typeId)
-  const widgetId = editor.controls.find(ctrl => ctrl.fieldId === source.id).widgetId
-  const defaultEditor = defaultEditors[source.type]
-  const sanityEquivalent = directMap[source.type]
+  const editor = data.editorInterfaces.find(
+    (ed) => ed.sys.contentType.sys.id === typeId
+  );
+  const widgetId = editor.controls.find((ctrl) => ctrl.fieldId === source.id)
+    .widgetId;
+  const defaultEditor = defaultEditors[source.type];
+  const sanityEquivalent = directMap[source.type];
 
   if (sanityEquivalent && widgetId === defaultEditor) {
-    return {type: sanityEquivalent}
+    return { type: sanityEquivalent };
   }
 
-  if (widgetId === 'urlEditor') {
-    return {type: 'url'}
+  if (widgetId === "urlEditor") {
+    return { type: "url" };
   }
 
-  if (widgetId === 'slugEditor') {
-    return determineSlugType(source, data, typeId)
+  if (widgetId === "slugEditor") {
+    return determineSlugType(source, data, typeId);
   }
 
-  if (!options.keepMarkdown && source.type === 'Text' && widgetId === 'markdown') {
+  if (
+    !options.keepMarkdown &&
+    source.type === "Text" &&
+    widgetId === "markdown"
+  ) {
     return {
-      type: 'array',
-      of: [{type: 'block'}, {type: 'image'}]
-    }
+      type: "array",
+      of: [{ type: "block" }, { type: "image" }],
+    };
   }
 
-  if (source.type === 'Text') {
-    return {type: 'text'}
+  if (source.type === "Text") {
+    return { type: "text" };
   }
 
-  if (source.type === 'Link') {
-    return determineRefType(source, data, typeId)
+  if (source.type === "Link") {
+    return determineRefType(source, data, typeId);
   }
 
-  if (source.type === 'Array') {
-    return determineArrayType(source, data, typeId)
+  if (source.type === "Array") {
+    return determineArrayType(source, data, typeId);
   }
 
-  if (sanityEquivalent && ['dropdown', 'radio'].includes(widgetId)) {
-    const {list, layout} = determineSelectOptions(source, data, typeId)
-    return {type: sanityEquivalent, options: {list, layout}}
+  if (sanityEquivalent && ["dropdown", "radio"].includes(widgetId)) {
+    const { list, layout } = determineSelectOptions(source, data, typeId);
+    return { type: sanityEquivalent, options: { list, layout } };
   }
 
-  if (source.type === 'Symbol') {
-    return {type: 'string'}
+  if (source.type === "Symbol") {
+    return { type: "string" };
+  }
+
+  if (source.type === "RichText") {
+    // this is a type we supply. See the portableTextType() function
+    return { type: "portableText" };
   }
 
   throw new Error(
     `Unhandled data type "${source.type}" with widget "${widgetId}" for field "${source.id}" of type "${typeId}"`
-  )
+  );
 }
 
 function determineSlugType(source, data, typeId) {
-  const type = data.contentTypes.find(typ => typ.sys.id === typeId)
-  const sourceField = type.displayField
+  const type = data.contentTypes.find((typ) => typ.sys.id === typeId);
+  const sourceField = type.displayField;
   if (!sourceField) {
-    throw new Error(`Unable to determine which field to extract slug from`)
+    throw new Error(`Unable to determine which field to extract slug from`);
   }
 
-  return {type: 'slug', options: {source: sourceField}}
+  return { type: "slug", options: { source: sourceField } };
 }
 
 function determineSelectOptions(source, data, typeId) {
-  const validations = source.items ? source.items.validations : source.validations
-  const onlyValues = (validations.find(val => val.in) || {}).in
-  const editor = data.editorInterfaces.find(ed => ed.sys.contentType.sys.id === typeId)
-  const widgetId = editor.controls.find(ctrl => ctrl.fieldId === source.id).widgetId
-  const layout = editorMap[widgetId]
+  const validations = source.items
+    ? source.items.validations
+    : source.validations;
+  const onlyValues = (validations.find((val) => val.in) || {}).in;
+  const editor = data.editorInterfaces.find(
+    (ed) => ed.sys.contentType.sys.id === typeId
+  );
+  const widgetId = editor.controls.find((ctrl) => ctrl.fieldId === source.id)
+    .widgetId;
+  const layout = editorMap[widgetId];
 
-  return onlyValues ? {list: onlyValues, layout} : {layout}
+  return onlyValues ? { list: onlyValues, layout } : { layout };
 }
 
 function determineArrayType(source, data, typeId) {
-  const itemsType = source.items.type
-  const onlyValues = (source.items.validations.find(val => val.in) || {}).in
+  const itemsType = source.items.type;
+  const onlyValues = (source.items.validations.find((val) => val.in) || {}).in;
 
-  const field = {type: 'array'}
-  const type = directMap[itemsType]
-  const {list, layout} = determineSelectOptions(source, data, typeId)
+  const field = { type: "array" };
+  const type = directMap[itemsType];
+  const { list, layout } = determineSelectOptions(source, data, typeId);
 
-  if (type === 'string' && onlyValues) {
-    field.of = [{type: 'string', options: {list, layout}}]
-    return field
+  if (type === "string" && onlyValues) {
+    field.of = [{ type: "string", options: { list, layout } }];
+    return field;
   }
 
   if (type) {
-    field.of = [{type, options: {layout}}]
-    return field
+    field.of = [{ type, options: { layout } }];
+    return field;
   }
 
-  if (itemsType === 'Link') {
-    field.of = [determineRefType(source.items, data)]
-    return field
+  if (itemsType === "Link") {
+    field.of = [determineRefType(source.items, data)];
+    return field;
   }
 
   throw new Error(
     `Unable to determine array items type for field "${source.id}" of type "${typeId}"`
-  )
+  );
 }
 
 function determineRefType(source, data) {
-  if (source.linkType === 'Entry') {
-    return determineEntryRefType(source, data)
+  if (source.linkType === "Entry") {
+    return determineEntryRefType(source, data);
   }
 
-  if (source.linkType === 'Asset') {
-    return determineAssetRefType(source, data)
+  if (source.linkType === "Asset") {
+    return determineAssetRefType(source, data);
   }
 
-  throw new Error(`Unhandled link type "${source.linkType}"`)
+  throw new Error(`Unhandled link type "${source.linkType}"`);
 }
 
 function determineAssetRefType(source, data) {
-  const mimeValidation = source.validations.find(val => val.linkMimetypeGroup) || {}
-  const mimeGroups = mimeValidation.linkMimetypeGroup || []
+  const mimeValidation =
+    source.validations.find((val) => val.linkMimetypeGroup) || {};
+  const mimeGroups = mimeValidation.linkMimetypeGroup || [];
 
-  if (mimeGroups.includes('image') || ['image', 'picture'].includes(source.id)) {
-    return {type: 'image'}
+  if (
+    mimeGroups.includes("image") ||
+    ["image", "picture"].includes(source.id)
+  ) {
+    return { type: "image" };
   }
 
   // @todo file/image?
-  return {type: 'file'}
+  return { type: "file" };
 }
 
 function determineEntryRefType(source, data) {
-  const typeValidation = source.validations.find(val => val.linkContentType) || {}
-  const linkTypes = (typeValidation.linkContentType || []).filter(typeName => {
-    // Validations can contain deleted content types - make sure to remove them
-    return data.contentTypes.some(type => type.sys.id === typeName)
-  })
+  const typeValidation =
+    source.validations.find((val) => val.linkContentType) || {};
+  const linkTypes = (typeValidation.linkContentType || []).filter(
+    (typeName) => {
+      // Validations can contain deleted content types - make sure to remove them
+      return data.contentTypes.some((type) => type.sys.id === typeName);
+    }
+  );
 
   if (linkTypes.length === 0) {
     // Allow referencing all types
     return {
-      type: 'reference',
-      to: data.contentTypes.map(type => ({type: type.sys.id}))
-    }
+      type: "reference",
+      to: data.contentTypes.map((type) => ({ type: type.sys.id })),
+    };
   }
 
-  return {type: 'reference', to: linkTypes.map(type => ({type}))}
+  return { type: "reference", to: linkTypes.map((type) => ({ type })) };
 }
 
-module.exports = transformSchema
+module.exports = transformSchema;

--- a/src/transformSchema.js
+++ b/src/transformSchema.js
@@ -1,60 +1,60 @@
-const builtIns = require("./builtinTypes");
+const builtIns = require('./builtinTypes')
 
 const directMap = {
-  Integer: "number",
-  Number: "number",
-  Symbol: "string",
-  Location: "geopoint",
-  Boolean: "boolean",
-  Date: "datetime",
-  Object: "object",
-};
+  Integer: 'number',
+  Number: 'number',
+  Symbol: 'string',
+  Location: 'geopoint',
+  Boolean: 'boolean',
+  Date: 'datetime',
+  Object: 'object',
+}
 
 const defaultEditors = {
-  Integer: "numberEditor",
-  Number: "numberEditor",
-  Symbol: "singleLine",
-  Location: "locationEditor",
-  Boolean: "boolean",
-  Date: "datePicker",
-  Object: "objectEditor",
-};
+  Integer: 'numberEditor',
+  Number: 'numberEditor',
+  Symbol: 'singleLine',
+  Location: 'locationEditor',
+  Boolean: 'boolean',
+  Date: 'datePicker',
+  Object: 'objectEditor',
+}
 
 const editorMap = {
-  radio: "radio",
-  dropdown: "dropdown",
-  tagEditor: "tags",
-};
+  radio: 'radio',
+  dropdown: 'dropdown',
+  tagEditor: 'tags',
+}
 
 function portableTextType(contentTypes) {
   const docReferences = contentTypes
-    .filter((typeDef) => {
-      return typeDef.type === "document";
+    .filter(typeDef => {
+      return typeDef.type === 'document'
     })
-    .map((doc) => ({
-      type: "reference",
+    .map(doc => ({
+      type: 'reference',
       name: `${doc.name}Ref`,
       to: [{ type: doc.name }],
-    }));
+    }))
 
   return {
-    name: "portableText",
-    type: "array",
-    title: "Rich text",
+    name: 'portableText',
+    type: 'array',
+    title: 'Rich text',
     of: [
-      { type: "block", of: [{ type: "image" }].concat(docReferences) },
-      { type: "break" },
-      { type: "image" },
+      { type: 'block', of: [{ type: 'image' }].concat(docReferences) },
+      { type: 'break' },
+      { type: 'image' },
     ].concat(docReferences),
-  };
+  }
 }
 
 function transformSchema(data, options) {
-  const contentTypes = data.contentTypes.map((type) =>
+  const contentTypes = data.contentTypes.map(type =>
     transformContentType(type, data, options)
-  );
+  )
 
-  return builtIns.concat(portableTextType(contentTypes)).concat(contentTypes);
+  return builtIns.concat(portableTextType(contentTypes)).concat(contentTypes)
 }
 
 function transformContentType(type, data, options) {
@@ -62,17 +62,17 @@ function transformContentType(type, data, options) {
     name: type.sys.id,
     title: type.name,
     description: type.description || undefined,
-    type: "document",
-  };
+    type: 'document',
+  }
 
   if (type.displayField) {
-    output.preview = { select: { title: type.displayField } };
+    output.preview = { select: { title: type.displayField } }
   }
 
   output.fields = type.fields
-    .filter((field) => !field.omitted)
-    .filter((field) => !shouldSkip(field, data, type.sys.id))
-    .map((source) =>
+    .filter(field => !field.omitted)
+    .filter(field => !shouldSkip(field, data, type.sys.id))
+    .map(source =>
       Object.assign(
         {
           name: source.id,
@@ -83,191 +83,189 @@ function transformContentType(type, data, options) {
         { type: undefined },
         contentfulTypeToSanityType(source, data, type.sys.id, options)
       )
-    );
+    )
 
-  return output;
+  return output
 }
 
 function isHidden(field) {
-  return field.disabled ? { hidden: true } : {};
+  return field.disabled ? { hidden: true } : {}
 }
 
 function isRequired(field) {
-  return field.required ? { required: true } : {};
+  return field.required ? { required: true } : {}
 }
 
 function shouldSkip(source, data, typeId) {
   const editor = data.editorInterfaces.find(
-    (ed) => ed.sys.contentType.sys.id === typeId
-  );
-  const widgetId = editor.controls.find((ctrl) => ctrl.fieldId === source.id)
-    .widgetId;
-  return source.type === "Object" && widgetId === "objectEditor";
+    ed => ed.sys.contentType.sys.id === typeId
+  )
+  const widgetId = editor.controls.find(ctrl => ctrl.fieldId === source.id)
+    .widgetId
+  return source.type === 'Object' && widgetId === 'objectEditor'
 }
 
 function contentfulTypeToSanityType(source, data, typeId, options) {
   const editor = data.editorInterfaces.find(
-    (ed) => ed.sys.contentType.sys.id === typeId
-  );
-  const widgetId = editor.controls.find((ctrl) => ctrl.fieldId === source.id)
-    .widgetId;
-  const defaultEditor = defaultEditors[source.type];
-  const sanityEquivalent = directMap[source.type];
+    ed => ed.sys.contentType.sys.id === typeId
+  )
+  const widgetId = editor.controls.find(ctrl => ctrl.fieldId === source.id)
+    .widgetId
+  const defaultEditor = defaultEditors[source.type]
+  const sanityEquivalent = directMap[source.type]
 
   if (sanityEquivalent && widgetId === defaultEditor) {
-    return { type: sanityEquivalent };
+    return { type: sanityEquivalent }
   }
 
-  if (widgetId === "urlEditor") {
-    return { type: "url" };
+  if (widgetId === 'urlEditor') {
+    return { type: 'url' }
   }
 
-  if (widgetId === "slugEditor") {
-    return determineSlugType(source, data, typeId);
+  if (widgetId === 'slugEditor') {
+    return determineSlugType(source, data, typeId)
   }
 
   if (
     !options.keepMarkdown &&
-    source.type === "Text" &&
-    widgetId === "markdown"
+    source.type === 'Text' &&
+    widgetId === 'markdown'
   ) {
     return {
-      type: "array",
-      of: [{ type: "block" }, { type: "image" }],
-    };
+      type: 'array',
+      of: [{ type: 'block' }, { type: 'image' }],
+    }
   }
 
-  if (source.type === "Text") {
-    return { type: "text" };
+  if (source.type === 'Text') {
+    return { type: 'text' }
   }
 
-  if (source.type === "Link") {
-    return determineRefType(source, data, typeId);
+  if (source.type === 'Link') {
+    return determineRefType(source, data, typeId)
   }
 
-  if (source.type === "Array") {
-    return determineArrayType(source, data, typeId);
+  if (source.type === 'Array') {
+    return determineArrayType(source, data, typeId)
   }
 
-  if (sanityEquivalent && ["dropdown", "radio"].includes(widgetId)) {
-    const { list, layout } = determineSelectOptions(source, data, typeId);
-    return { type: sanityEquivalent, options: { list, layout } };
+  if (sanityEquivalent && ['dropdown', 'radio'].includes(widgetId)) {
+    const { list, layout } = determineSelectOptions(source, data, typeId)
+    return { type: sanityEquivalent, options: { list, layout } }
   }
 
-  if (source.type === "Symbol") {
-    return { type: "string" };
+  if (source.type === 'Symbol') {
+    return { type: 'string' }
   }
 
-  if (source.type === "RichText") {
+  if (source.type === 'RichText') {
     // this is a type we supply. See the portableTextType() function
-    return { type: "portableText" };
+    return { type: 'portableText' }
   }
 
   throw new Error(
     `Unhandled data type "${source.type}" with widget "${widgetId}" for field "${source.id}" of type "${typeId}"`
-  );
+  )
 }
 
 function determineSlugType(source, data, typeId) {
-  const type = data.contentTypes.find((typ) => typ.sys.id === typeId);
-  const sourceField = type.displayField;
+  const type = data.contentTypes.find(typ => typ.sys.id === typeId)
+  const sourceField = type.displayField
   if (!sourceField) {
-    throw new Error(`Unable to determine which field to extract slug from`);
+    throw new Error(`Unable to determine which field to extract slug from`)
   }
 
-  return { type: "slug", options: { source: sourceField } };
+  return { type: 'slug', options: { source: sourceField } }
 }
 
 function determineSelectOptions(source, data, typeId) {
   const validations = source.items
     ? source.items.validations
-    : source.validations;
-  const onlyValues = (validations.find((val) => val.in) || {}).in;
+    : source.validations
+  const onlyValues = (validations.find(val => val.in) || {}).in
   const editor = data.editorInterfaces.find(
-    (ed) => ed.sys.contentType.sys.id === typeId
-  );
-  const widgetId = editor.controls.find((ctrl) => ctrl.fieldId === source.id)
-    .widgetId;
-  const layout = editorMap[widgetId];
+    ed => ed.sys.contentType.sys.id === typeId
+  )
+  const widgetId = editor.controls.find(ctrl => ctrl.fieldId === source.id)
+    .widgetId
+  const layout = editorMap[widgetId]
 
-  return onlyValues ? { list: onlyValues, layout } : { layout };
+  return onlyValues ? { list: onlyValues, layout } : { layout }
 }
 
 function determineArrayType(source, data, typeId) {
-  const itemsType = source.items.type;
-  const onlyValues = (source.items.validations.find((val) => val.in) || {}).in;
+  const itemsType = source.items.type
+  const onlyValues = (source.items.validations.find(val => val.in) || {}).in
 
-  const field = { type: "array" };
-  const type = directMap[itemsType];
-  const { list, layout } = determineSelectOptions(source, data, typeId);
+  const field = { type: 'array' }
+  const type = directMap[itemsType]
+  const { list, layout } = determineSelectOptions(source, data, typeId)
 
-  if (type === "string" && onlyValues) {
-    field.of = [{ type: "string", options: { list, layout } }];
-    return field;
+  if (type === 'string' && onlyValues) {
+    field.of = [{ type: 'string', options: { list, layout } }]
+    return field
   }
 
   if (type) {
-    field.of = [{ type, options: { layout } }];
-    return field;
+    field.of = [{ type, options: { layout } }]
+    return field
   }
 
-  if (itemsType === "Link") {
-    field.of = [determineRefType(source.items, data)];
-    return field;
+  if (itemsType === 'Link') {
+    field.of = [determineRefType(source.items, data)]
+    return field
   }
 
   throw new Error(
     `Unable to determine array items type for field "${source.id}" of type "${typeId}"`
-  );
+  )
 }
 
 function determineRefType(source, data) {
-  if (source.linkType === "Entry") {
-    return determineEntryRefType(source, data);
+  if (source.linkType === 'Entry') {
+    return determineEntryRefType(source, data)
   }
 
-  if (source.linkType === "Asset") {
-    return determineAssetRefType(source, data);
+  if (source.linkType === 'Asset') {
+    return determineAssetRefType(source, data)
   }
 
-  throw new Error(`Unhandled link type "${source.linkType}"`);
+  throw new Error(`Unhandled link type "${source.linkType}"`)
 }
 
 function determineAssetRefType(source, data) {
   const mimeValidation =
-    source.validations.find((val) => val.linkMimetypeGroup) || {};
-  const mimeGroups = mimeValidation.linkMimetypeGroup || [];
+    source.validations.find(val => val.linkMimetypeGroup) || {}
+  const mimeGroups = mimeValidation.linkMimetypeGroup || []
 
   if (
-    mimeGroups.includes("image") ||
-    ["image", "picture"].includes(source.id)
+    mimeGroups.includes('image') ||
+    ['image', 'picture'].includes(source.id)
   ) {
-    return { type: "image" };
+    return { type: 'image' }
   }
 
   // @todo file/image?
-  return { type: "file" };
+  return { type: 'file' }
 }
 
 function determineEntryRefType(source, data) {
   const typeValidation =
-    source.validations.find((val) => val.linkContentType) || {};
-  const linkTypes = (typeValidation.linkContentType || []).filter(
-    (typeName) => {
-      // Validations can contain deleted content types - make sure to remove them
-      return data.contentTypes.some((type) => type.sys.id === typeName);
-    }
-  );
+    source.validations.find(val => val.linkContentType) || {}
+  const linkTypes = (typeValidation.linkContentType || []).filter(typeName => {
+    // Validations can contain deleted content types - make sure to remove them
+    return data.contentTypes.some(type => type.sys.id === typeName)
+  })
 
   if (linkTypes.length === 0) {
     // Allow referencing all types
     return {
-      type: "reference",
-      to: data.contentTypes.map((type) => ({ type: type.sys.id })),
-    };
+      type: 'reference',
+      to: data.contentTypes.map(type => ({ type: type.sys.id })),
+    }
   }
 
-  return { type: "reference", to: linkTypes.map((type) => ({ type })) };
+  return { type: 'reference', to: linkTypes.map(type => ({ type })) }
 }
 
-module.exports = transformSchema;
+module.exports = transformSchema

--- a/src/transformSchema.js
+++ b/src/transformSchema.js
@@ -7,7 +7,7 @@ const directMap = {
   Location: 'geopoint',
   Boolean: 'boolean',
   Date: 'datetime',
-  Object: 'object',
+  Object: 'object'
 }
 
 const defaultEditors = {
@@ -17,13 +17,13 @@ const defaultEditors = {
   Location: 'locationEditor',
   Boolean: 'boolean',
   Date: 'datePicker',
-  Object: 'objectEditor',
+  Object: 'objectEditor'
 }
 
 const editorMap = {
   radio: 'radio',
   dropdown: 'dropdown',
-  tagEditor: 'tags',
+  tagEditor: 'tags'
 }
 
 function portableTextType(contentTypes) {
@@ -34,7 +34,7 @@ function portableTextType(contentTypes) {
     .map(doc => ({
       type: 'reference',
       name: `${doc.name}Ref`,
-      to: [{ type: doc.name }],
+      to: [{type: doc.name}]
     }))
 
   return {
@@ -42,10 +42,10 @@ function portableTextType(contentTypes) {
     type: 'array',
     title: 'Rich text',
     of: [
-      { type: 'block', of: [{ type: 'image' }].concat(docReferences) },
-      { type: 'break' },
-      { type: 'image' },
-    ].concat(docReferences),
+      {type: 'block', of: [{type: 'image'}].concat(docReferences)},
+      {type: 'break'},
+      {type: 'image'}
+    ].concat(docReferences)
   }
 }
 
@@ -62,11 +62,11 @@ function transformContentType(type, data, options) {
     name: type.sys.id,
     title: type.name,
     description: type.description || undefined,
-    type: 'document',
+    type: 'document'
   }
 
   if (type.displayField) {
-    output.preview = { select: { title: type.displayField } }
+    output.preview = {select: {title: type.displayField}}
   }
 
   output.fields = type.fields
@@ -76,11 +76,11 @@ function transformContentType(type, data, options) {
       Object.assign(
         {
           name: source.id,
-          title: source.name,
+          title: source.name
         },
         isRequired(source),
         isHidden(source),
-        { type: undefined },
+        {type: undefined},
         contentfulTypeToSanityType(source, data, type.sys.id, options)
       )
     )
@@ -89,11 +89,11 @@ function transformContentType(type, data, options) {
 }
 
 function isHidden(field) {
-  return field.disabled ? { hidden: true } : {}
+  return field.disabled ? {hidden: true} : {}
 }
 
 function isRequired(field) {
-  return field.required ? { required: true } : {}
+  return field.required ? {required: true} : {}
 }
 
 function shouldSkip(source, data, typeId) {
@@ -115,11 +115,11 @@ function contentfulTypeToSanityType(source, data, typeId, options) {
   const sanityEquivalent = directMap[source.type]
 
   if (sanityEquivalent && widgetId === defaultEditor) {
-    return { type: sanityEquivalent }
+    return {type: sanityEquivalent}
   }
 
   if (widgetId === 'urlEditor') {
-    return { type: 'url' }
+    return {type: 'url'}
   }
 
   if (widgetId === 'slugEditor') {
@@ -133,12 +133,12 @@ function contentfulTypeToSanityType(source, data, typeId, options) {
   ) {
     return {
       type: 'array',
-      of: [{ type: 'block' }, { type: 'image' }],
+      of: [{type: 'block'}, {type: 'image'}]
     }
   }
 
   if (source.type === 'Text') {
-    return { type: 'text' }
+    return {type: 'text'}
   }
 
   if (source.type === 'Link') {
@@ -150,17 +150,17 @@ function contentfulTypeToSanityType(source, data, typeId, options) {
   }
 
   if (sanityEquivalent && ['dropdown', 'radio'].includes(widgetId)) {
-    const { list, layout } = determineSelectOptions(source, data, typeId)
-    return { type: sanityEquivalent, options: { list, layout } }
+    const {list, layout} = determineSelectOptions(source, data, typeId)
+    return {type: sanityEquivalent, options: {list, layout}}
   }
 
   if (source.type === 'Symbol') {
-    return { type: 'string' }
+    return {type: 'string'}
   }
 
   if (source.type === 'RichText') {
     // this is a type we supply. See the portableTextType() function
-    return { type: 'portableText' }
+    return {type: 'portableText'}
   }
 
   throw new Error(
@@ -175,7 +175,7 @@ function determineSlugType(source, data, typeId) {
     throw new Error(`Unable to determine which field to extract slug from`)
   }
 
-  return { type: 'slug', options: { source: sourceField } }
+  return {type: 'slug', options: {source: sourceField}}
 }
 
 function determineSelectOptions(source, data, typeId) {
@@ -190,24 +190,24 @@ function determineSelectOptions(source, data, typeId) {
     .widgetId
   const layout = editorMap[widgetId]
 
-  return onlyValues ? { list: onlyValues, layout } : { layout }
+  return onlyValues ? {list: onlyValues, layout} : {layout}
 }
 
 function determineArrayType(source, data, typeId) {
   const itemsType = source.items.type
   const onlyValues = (source.items.validations.find(val => val.in) || {}).in
 
-  const field = { type: 'array' }
+  const field = {type: 'array'}
   const type = directMap[itemsType]
-  const { list, layout } = determineSelectOptions(source, data, typeId)
+  const {list, layout} = determineSelectOptions(source, data, typeId)
 
   if (type === 'string' && onlyValues) {
-    field.of = [{ type: 'string', options: { list, layout } }]
+    field.of = [{type: 'string', options: {list, layout}}]
     return field
   }
 
   if (type) {
-    field.of = [{ type, options: { layout } }]
+    field.of = [{type, options: {layout}}]
     return field
   }
 
@@ -242,11 +242,11 @@ function determineAssetRefType(source, data) {
     mimeGroups.includes('image') ||
     ['image', 'picture'].includes(source.id)
   ) {
-    return { type: 'image' }
+    return {type: 'image'}
   }
 
   // @todo file/image?
-  return { type: 'file' }
+  return {type: 'file'}
 }
 
 function determineEntryRefType(source, data) {
@@ -261,11 +261,11 @@ function determineEntryRefType(source, data) {
     // Allow referencing all types
     return {
       type: 'reference',
-      to: data.contentTypes.map(type => ({ type: type.sys.id })),
+      to: data.contentTypes.map(type => ({type: type.sys.id}))
     }
   }
 
-  return { type: 'reference', to: linkTypes.map(type => ({ type })) }
+  return {type: 'reference', to: linkTypes.map(type => ({type}))}
 }
 
 module.exports = transformSchema

--- a/test/fixtures/hrexport.json
+++ b/test/fixtures/hrexport.json
@@ -1,0 +1,1254 @@
+{
+  "contentTypes": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "blogPost",
+        "type": "ContentType",
+        "createdAt": "2019-05-06T13:06:27.127Z",
+        "updatedAt": "2020-06-22T16:25:54.769Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 5,
+        "publishedAt": "2020-06-22T16:25:54.769Z",
+        "firstPublishedAt": "2019-05-06T13:06:27.619Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 3,
+        "version": 6,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "displayField": "title",
+      "name": "Blog Post",
+      "description": null,
+      "fields": [
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "slug",
+          "name": "Slug",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "heroImage",
+          "name": "Hero Image",
+          "type": "Link",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Asset"
+        },
+        {
+          "id": "description",
+          "name": "Description",
+          "type": "Text",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "body",
+          "name": "Body",
+          "type": "Text",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "author",
+          "name": "Author",
+          "type": "Link",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "linkContentType": [
+                "person"
+              ]
+            }
+          ],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Entry"
+        },
+        {
+          "id": "publishDate",
+          "name": "Publish Date",
+          "type": "Date",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "tags",
+          "name": "Tags",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Symbol",
+            "validations": [
+              {
+                "in": [
+                  "general",
+                  "javascript",
+                  "static-sites"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "id": "richBody",
+          "name": "richBody",
+          "type": "RichText",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "nodes": {
+              }
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "person",
+        "type": "ContentType",
+        "createdAt": "2019-05-06T13:06:27.242Z",
+        "updatedAt": "2019-05-06T13:06:27.725Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 1,
+        "publishedAt": "2019-05-06T13:06:27.725Z",
+        "firstPublishedAt": "2019-05-06T13:06:27.725Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 2,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "displayField": "name",
+      "name": "Person",
+      "description": null,
+      "fields": [
+        {
+          "id": "name",
+          "name": "Name",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "company",
+          "name": "Company",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "shortBio",
+          "name": "Short Bio",
+          "type": "Text",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "email",
+          "name": "Email",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "phone",
+          "name": "Phone",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "facebook",
+          "name": "Facebook",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "twitter",
+          "name": "Twitter",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "github",
+          "name": "Github",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "image",
+          "name": "Image",
+          "type": "Link",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Asset"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "richTextTests",
+        "type": "ContentType",
+        "createdAt": "2020-06-19T12:17:08.778Z",
+        "updatedAt": "2020-06-19T15:06:20.284Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 9,
+        "publishedAt": "2020-06-19T15:06:20.284Z",
+        "firstPublishedAt": "2020-06-19T12:17:09.210Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 5,
+        "version": 10,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "displayField": "title",
+      "name": "Rich text tests",
+      "description": "",
+      "fields": [
+        {
+          "id": "title",
+          "name": "title",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "body",
+          "name": "body",
+          "type": "RichText",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "nodes": {
+              }
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "limitedRichText",
+          "name": "Limited rich text",
+          "type": "RichText",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "nodes": {
+              }
+            },
+            {
+              "enabledNodeTypes": [
+                "heading-1",
+                "heading-2",
+                "heading-3",
+                "heading-4",
+                "heading-5",
+                "heading-6",
+                "ordered-list",
+                "unordered-list",
+                "hr",
+                "blockquote",
+                "embedded-asset-block",
+                "embedded-entry-block"
+              ],
+              "message": "Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, asset, and block entry nodes are allowed"
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "isolatedRichText",
+        "type": "ContentType",
+        "createdAt": "2020-06-24T16:04:39.644Z",
+        "updatedAt": "2020-06-24T16:04:40.195Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 1,
+        "publishedAt": "2020-06-24T16:04:40.195Z",
+        "firstPublishedAt": "2020-06-24T16:04:40.195Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 2,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "displayField": null,
+      "name": "Isolated RichText",
+      "description": "",
+      "fields": [
+        {
+          "id": "body",
+          "name": "body",
+          "type": "RichText",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "nodes": {
+              }
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    }
+  ],
+  "editorInterfaces": [
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "space": {
+          "sys": {
+            "id": "x2j9oc2f28ow",
+            "type": "Link",
+            "linkType": "Space"
+          }
+        },
+        "version": 5,
+        "createdAt": "2019-05-06T13:06:27.750Z",
+        "createdBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "updatedAt": "2020-06-22T16:25:55.431Z",
+        "updatedBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "id": "blogPost",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "title",
+          "widgetId": "singleLine",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "slug",
+          "widgetId": "singleLine",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "heroImage",
+          "widgetId": "assetLinkEditor",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "description",
+          "widgetId": "markdown",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "body",
+          "widgetId": "markdown",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "author",
+          "settings": {
+            "showLinkEntityAction": true,
+            "showCreateEntityAction": true
+          },
+          "widgetId": "entryLinkEditor",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "publishDate",
+          "widgetId": "datePicker",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "tags",
+          "widgetId": "listInput",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "richBody",
+          "widgetId": "richTextEditor",
+          "widgetNamespace": "builtin"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "space": {
+          "sys": {
+            "id": "x2j9oc2f28ow",
+            "type": "Link",
+            "linkType": "Space"
+          }
+        },
+        "version": 1,
+        "createdAt": "2019-05-06T13:06:27.854Z",
+        "createdBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "updatedAt": "2019-05-06T13:06:27.854Z",
+        "updatedBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "id": "person",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "name",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "title",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "company",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "shortBio",
+          "widgetId": "markdown"
+        },
+        {
+          "fieldId": "email",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "phone",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "facebook",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "twitter",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "github",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "image",
+          "widgetId": "assetLinkEditor"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "space": {
+          "sys": {
+            "id": "x2j9oc2f28ow",
+            "type": "Link",
+            "linkType": "Space"
+          }
+        },
+        "version": 10,
+        "createdAt": "2020-06-19T12:17:09.298Z",
+        "createdBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "updatedAt": "2020-06-19T15:06:20.790Z",
+        "updatedBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "id": "richTextTests",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "title",
+          "widgetId": "singleLine",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "body",
+          "widgetId": "richTextEditor",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "limitedRichText",
+          "widgetId": "richTextEditor",
+          "widgetNamespace": "builtin"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "space": {
+          "sys": {
+            "id": "x2j9oc2f28ow",
+            "type": "Link",
+            "linkType": "Space"
+          }
+        },
+        "version": 2,
+        "createdAt": "2020-06-24T16:04:40.573Z",
+        "createdBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "updatedAt": "2020-06-24T16:04:41.211Z",
+        "updatedBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "id": "isolatedRichText",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "body",
+          "widgetId": "richTextEditor",
+          "widgetNamespace": "builtin"
+        }
+      ]
+    }
+  ],
+  "entries": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "54p5OT64dCgd6tWmPFKUxW",
+        "type": "Entry",
+        "createdAt": "2020-06-24T16:04:47.629Z",
+        "updatedAt": "2020-06-24T16:04:59.828Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 3,
+        "publishedAt": "2020-06-24T16:04:59.828Z",
+        "firstPublishedAt": "2020-06-24T16:04:59.828Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 4,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "isolatedRichText"
+          }
+        }
+      },
+      "fields": {
+        "body": {
+          "en-US": {
+            "nodeType": "document",
+            "data": {
+            },
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "First paragraph",
+                    "marks": [
+                    ],
+                    "data": {
+                    }
+                  }
+                ],
+                "data": {
+                }
+              },
+              {
+                "nodeType": "hr",
+                "content": [
+                ],
+                "data": {
+                }
+              },
+              {
+                "nodeType": "paragraph",
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "Second paragraph",
+                    "marks": [
+                    ],
+                    "data": {
+                    }
+                  }
+                ],
+                "data": {
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "assets": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "6Od9v3wzLOysiMum0Wkmme",
+        "type": "Asset",
+        "createdAt": "2019-05-06T13:06:28.375Z",
+        "updatedAt": "2019-05-06T13:06:33.353Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 2,
+        "publishedAt": "2019-05-06T13:06:33.353Z",
+        "firstPublishedAt": "2019-05-06T13:06:33.353Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 3,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Woman with black hat"
+        },
+        "description": {
+          "en-US": "Woman wearing a black hat"
+        },
+        "file": {
+          "en-US": {
+            "url": "//images.ctfassets.net/x2j9oc2f28ow/6Od9v3wzLOysiMum0Wkmme/683bf4b5de422ed9a29e66e0fc4604ca/cameron-kirby-88711.jpg",
+            "details": {
+              "size": 7316629,
+              "image": {
+                "width": 3000,
+                "height": 2000
+              }
+            },
+            "fileName": "cameron-kirby-88711.jpg",
+            "contentType": "image/jpeg"
+          }
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "7orLdboQQowIUs22KAW4U",
+        "type": "Asset",
+        "createdAt": "2019-05-06T13:06:28.379Z",
+        "updatedAt": "2019-05-06T13:06:33.352Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 2,
+        "publishedAt": "2019-05-06T13:06:33.352Z",
+        "firstPublishedAt": "2019-05-06T13:06:33.352Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 3,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Sparkler"
+        },
+        "description": {
+          "en-US": "John with Sparkler"
+        },
+        "file": {
+          "en-US": {
+            "url": "//images.ctfassets.net/x2j9oc2f28ow/7orLdboQQowIUs22KAW4U/7781b3d7ea651768d2a6eac6e65b2bcd/matt-palmer-254999.jpg",
+            "details": {
+              "size": 2293094,
+              "image": {
+                "width": 3000,
+                "height": 2000
+              }
+            },
+            "fileName": "matt-palmer-254999.jpg",
+            "contentType": "image/jpeg"
+          }
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "4NzwDSDlGECGIiokKomsyI",
+        "type": "Asset",
+        "createdAt": "2019-05-06T13:06:28.382Z",
+        "updatedAt": "2019-05-06T13:06:33.458Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 2,
+        "publishedAt": "2019-05-06T13:06:33.458Z",
+        "firstPublishedAt": "2019-05-06T13:06:33.458Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 3,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "City"
+        },
+        "description": {
+          "en-US": "City pictured from the sky"
+        },
+        "file": {
+          "en-US": {
+            "url": "//images.ctfassets.net/x2j9oc2f28ow/4NzwDSDlGECGIiokKomsyI/e1ad3c13133f35d2134ad2285b926702/denys-nevozhai-100695.jpg",
+            "details": {
+              "size": 15736986,
+              "image": {
+                "width": 3992,
+                "height": 2992
+              }
+            },
+            "fileName": "denys-nevozhai-100695.jpg",
+            "contentType": "image/jpeg"
+          }
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "4shwYI3POEGkw0Eg6kcyaQ",
+        "type": "Asset",
+        "createdAt": "2019-05-06T13:06:28.393Z",
+        "updatedAt": "2019-05-06T13:06:33.381Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 2,
+        "publishedAt": "2019-05-06T13:06:33.381Z",
+        "firstPublishedAt": "2019-05-06T13:06:33.381Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 3,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Man in the fields"
+        },
+        "description": {
+          "en-US": "Tattooed man walking in a field"
+        },
+        "file": {
+          "en-US": {
+            "url": "//images.ctfassets.net/x2j9oc2f28ow/4shwYI3POEGkw0Eg6kcyaQ/fc7101c4cd83bd4baa6e1ff5ffd21d1b/felix-russell-saw-112140.jpg",
+            "details": {
+              "size": 4539181,
+              "image": {
+                "width": 2500,
+                "height": 1667
+              }
+            },
+            "fileName": "felix-russell-saw-112140.jpg",
+            "contentType": "image/jpeg"
+          }
+        }
+      }
+    }
+  ],
+  "locales": [
+    {
+      "name": "English (United States)",
+      "code": "en-US",
+      "fallbackCode": null,
+      "default": true,
+      "contentManagementApi": true,
+      "contentDeliveryApi": true,
+      "optional": false,
+      "sys": {
+        "type": "Locale",
+        "id": "5houKx9MbN34ShZCWtXr6u",
+        "version": 1,
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "environment": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Environment",
+            "id": "master"
+          }
+        },
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "createdAt": "2019-05-06T13:06:25Z",
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedAt": "2019-05-06T13:06:25Z"
+      }
+    }
+  ],
+  "webhooks": [
+  ],
+  "roles": [
+  ]
+}

--- a/test/fixtures/richText.json
+++ b/test/fixtures/richText.json
@@ -1,0 +1,1756 @@
+{
+  "contentTypes": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "blogPost",
+        "type": "ContentType",
+        "createdAt": "2019-05-06T13:06:27.127Z",
+        "updatedAt": "2020-06-22T16:25:54.769Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 5,
+        "publishedAt": "2020-06-22T16:25:54.769Z",
+        "firstPublishedAt": "2019-05-06T13:06:27.619Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 3,
+        "version": 6,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "displayField": "title",
+      "name": "Blog Post",
+      "description": null,
+      "fields": [
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "slug",
+          "name": "Slug",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "heroImage",
+          "name": "Hero Image",
+          "type": "Link",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Asset"
+        },
+        {
+          "id": "description",
+          "name": "Description",
+          "type": "Text",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "body",
+          "name": "Body",
+          "type": "Text",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "author",
+          "name": "Author",
+          "type": "Link",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "linkContentType": [
+                "person"
+              ]
+            }
+          ],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Entry"
+        },
+        {
+          "id": "publishDate",
+          "name": "Publish Date",
+          "type": "Date",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "tags",
+          "name": "Tags",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Symbol",
+            "validations": [
+              {
+                "in": [
+                  "general",
+                  "javascript",
+                  "static-sites"
+                ]
+              }
+            ]
+          }
+        },
+        {
+          "id": "richBody",
+          "name": "richBody",
+          "type": "RichText",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "nodes": {
+              }
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "person",
+        "type": "ContentType",
+        "createdAt": "2019-05-06T13:06:27.242Z",
+        "updatedAt": "2019-05-06T13:06:27.725Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 1,
+        "publishedAt": "2019-05-06T13:06:27.725Z",
+        "firstPublishedAt": "2019-05-06T13:06:27.725Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 2,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "displayField": "name",
+      "name": "Person",
+      "description": null,
+      "fields": [
+        {
+          "id": "name",
+          "name": "Name",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "company",
+          "name": "Company",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "shortBio",
+          "name": "Short Bio",
+          "type": "Text",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "email",
+          "name": "Email",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "phone",
+          "name": "Phone",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "facebook",
+          "name": "Facebook",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "twitter",
+          "name": "Twitter",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "github",
+          "name": "Github",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "image",
+          "name": "Image",
+          "type": "Link",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Asset"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "richTextTests",
+        "type": "ContentType",
+        "createdAt": "2020-06-19T12:17:08.778Z",
+        "updatedAt": "2020-06-19T15:06:20.284Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 9,
+        "publishedAt": "2020-06-19T15:06:20.284Z",
+        "firstPublishedAt": "2020-06-19T12:17:09.210Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 5,
+        "version": 10,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "displayField": "title",
+      "name": "Rich text tests",
+      "description": "",
+      "fields": [
+        {
+          "id": "title",
+          "name": "title",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "body",
+          "name": "body",
+          "type": "RichText",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "nodes": {
+              }
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "limitedRichText",
+          "name": "Limited rich text",
+          "type": "RichText",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "nodes": {
+              }
+            },
+            {
+              "enabledNodeTypes": [
+                "heading-1",
+                "heading-2",
+                "heading-3",
+                "heading-4",
+                "heading-5",
+                "heading-6",
+                "ordered-list",
+                "unordered-list",
+                "hr",
+                "blockquote",
+                "embedded-asset-block",
+                "embedded-entry-block"
+              ],
+              "message": "Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, asset, and block entry nodes are allowed"
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "isolatedRichText",
+        "type": "ContentType",
+        "createdAt": "2020-06-24T16:04:39.644Z",
+        "updatedAt": "2020-06-24T16:04:40.195Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 1,
+        "publishedAt": "2020-06-24T16:04:40.195Z",
+        "firstPublishedAt": "2020-06-24T16:04:40.195Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 2,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "displayField": null,
+      "name": "Isolated RichText",
+      "description": "",
+      "fields": [
+        {
+          "id": "body",
+          "name": "body",
+          "type": "RichText",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "nodes": {
+              }
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "fullRichText",
+        "type": "ContentType",
+        "createdAt": "2020-06-24T16:34:01.514Z",
+        "updatedAt": "2020-06-24T16:34:02.575Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 1,
+        "publishedAt": "2020-06-24T16:34:02.575Z",
+        "firstPublishedAt": "2020-06-24T16:34:02.575Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 2,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "displayField": null,
+      "name": "Full RichText",
+      "description": "",
+      "fields": [
+        {
+          "id": "body",
+          "name": "body",
+          "type": "RichText",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "nodes": {
+              }
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    }
+  ],
+  "editorInterfaces": [
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "space": {
+          "sys": {
+            "id": "x2j9oc2f28ow",
+            "type": "Link",
+            "linkType": "Space"
+          }
+        },
+        "version": 5,
+        "createdAt": "2019-05-06T13:06:27.750Z",
+        "createdBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "updatedAt": "2020-06-22T16:25:55.431Z",
+        "updatedBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "id": "blogPost",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "title",
+          "widgetId": "singleLine",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "slug",
+          "widgetId": "singleLine",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "heroImage",
+          "widgetId": "assetLinkEditor",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "description",
+          "widgetId": "markdown",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "body",
+          "widgetId": "markdown",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "author",
+          "settings": {
+            "showLinkEntityAction": true,
+            "showCreateEntityAction": true
+          },
+          "widgetId": "entryLinkEditor",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "publishDate",
+          "widgetId": "datePicker",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "tags",
+          "widgetId": "listInput",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "richBody",
+          "widgetId": "richTextEditor",
+          "widgetNamespace": "builtin"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "space": {
+          "sys": {
+            "id": "x2j9oc2f28ow",
+            "type": "Link",
+            "linkType": "Space"
+          }
+        },
+        "version": 1,
+        "createdAt": "2019-05-06T13:06:27.854Z",
+        "createdBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "updatedAt": "2019-05-06T13:06:27.854Z",
+        "updatedBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "id": "person",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "name",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "title",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "company",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "shortBio",
+          "widgetId": "markdown"
+        },
+        {
+          "fieldId": "email",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "phone",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "facebook",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "twitter",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "github",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "image",
+          "widgetId": "assetLinkEditor"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "space": {
+          "sys": {
+            "id": "x2j9oc2f28ow",
+            "type": "Link",
+            "linkType": "Space"
+          }
+        },
+        "version": 10,
+        "createdAt": "2020-06-19T12:17:09.298Z",
+        "createdBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "updatedAt": "2020-06-19T15:06:20.790Z",
+        "updatedBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "id": "richTextTests",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "title",
+          "widgetId": "singleLine",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "body",
+          "widgetId": "richTextEditor",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "limitedRichText",
+          "widgetId": "richTextEditor",
+          "widgetNamespace": "builtin"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "space": {
+          "sys": {
+            "id": "x2j9oc2f28ow",
+            "type": "Link",
+            "linkType": "Space"
+          }
+        },
+        "version": 2,
+        "createdAt": "2020-06-24T16:04:40.573Z",
+        "createdBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "updatedAt": "2020-06-24T16:04:41.211Z",
+        "updatedBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "id": "isolatedRichText",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "body",
+          "widgetId": "richTextEditor",
+          "widgetNamespace": "builtin"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "space": {
+          "sys": {
+            "id": "x2j9oc2f28ow",
+            "type": "Link",
+            "linkType": "Space"
+          }
+        },
+        "version": 2,
+        "createdAt": "2020-06-24T16:34:02.714Z",
+        "createdBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "updatedAt": "2020-06-24T16:34:03.400Z",
+        "updatedBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "id": "fullRichText",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "body",
+          "widgetId": "richTextEditor",
+          "widgetNamespace": "builtin"
+        }
+      ]
+    }
+  ],
+  "entries": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "7fPF5lIYLjJv64l7n3Gn05",
+        "type": "Entry",
+        "createdAt": "2020-06-24T16:34:11.336Z",
+        "updatedAt": "2020-06-24T16:37:27.697Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 19,
+        "publishedAt": "2020-06-24T16:37:27.697Z",
+        "firstPublishedAt": "2020-06-24T16:35:46.018Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 3,
+        "version": 20,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "fullRichText"
+          }
+        }
+      },
+      "fields": {
+        "body": {
+          "en-US": {
+            "nodeType": "document",
+            "data": {
+            },
+            "content": [
+              {
+                "nodeType": "heading-1",
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "Heading 1",
+                    "marks": [
+                    ],
+                    "data": {
+                    }
+                  }
+                ],
+                "data": {
+                }
+              },
+              {
+                "nodeType": "paragraph",
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "Paragraph with ",
+                    "marks": [
+                    ],
+                    "data": {
+                    }
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": "bold",
+                    "marks": [
+                      {
+                        "type": "bold"
+                      }
+                    ],
+                    "data": {
+                    }
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": ", ",
+                    "marks": [
+                    ],
+                    "data": {
+                    }
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": "italics",
+                    "marks": [
+                      {
+                        "type": "italic"
+                      }
+                    ],
+                    "data": {
+                    }
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": ", ",
+                    "marks": [
+                    ],
+                    "data": {
+                    }
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": "underline",
+                    "marks": [
+                      {
+                        "type": "underline"
+                      }
+                    ],
+                    "data": {
+                    }
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": " and ",
+                    "marks": [
+                    ],
+                    "data": {
+                    }
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": "code",
+                    "marks": [
+                      {
+                        "type": "code"
+                      }
+                    ],
+                    "data": {
+                    }
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": ".",
+                    "marks": [
+                    ],
+                    "data": {
+                    }
+                  }
+                ],
+                "data": {
+                }
+              },
+              {
+                "nodeType": "paragraph",
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "A link to my ",
+                    "marks": [
+                    ],
+                    "data": {
+                    }
+                  },
+                  {
+                    "nodeType": "hyperlink",
+                    "content": [
+                      {
+                        "nodeType": "text",
+                        "value": "homepage",
+                        "marks": [
+                        ],
+                        "data": {
+                        }
+                      }
+                    ],
+                    "data": {
+                      "uri": "https://www.twitter.com/runeb"
+                    }
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": "",
+                    "marks": [
+                    ],
+                    "data": {
+                    }
+                  }
+                ],
+                "data": {
+                }
+              },
+              {
+                "nodeType": "unordered-list",
+                "content": [
+                  {
+                    "nodeType": "list-item",
+                    "content": [
+                      {
+                        "nodeType": "paragraph",
+                        "content": [
+                          {
+                            "nodeType": "text",
+                            "value": "Bullet one",
+                            "marks": [
+                            ],
+                            "data": {
+                            }
+                          }
+                        ],
+                        "data": {
+                        }
+                      }
+                    ],
+                    "data": {
+                    }
+                  },
+                  {
+                    "nodeType": "list-item",
+                    "content": [
+                      {
+                        "nodeType": "paragraph",
+                        "content": [
+                          {
+                            "nodeType": "text",
+                            "value": "Bullet two",
+                            "marks": [
+                            ],
+                            "data": {
+                            }
+                          }
+                        ],
+                        "data": {
+                        }
+                      }
+                    ],
+                    "data": {
+                    }
+                  },
+                  {
+                    "nodeType": "list-item",
+                    "content": [
+                      {
+                        "nodeType": "paragraph",
+                        "content": [
+                          {
+                            "nodeType": "text",
+                            "value": "Bullet three",
+                            "marks": [
+                            ],
+                            "data": {
+                            }
+                          }
+                        ],
+                        "data": {
+                        }
+                      }
+                    ],
+                    "data": {
+                    }
+                  }
+                ],
+                "data": {
+                }
+              },
+              {
+                "nodeType": "ordered-list",
+                "content": [
+                  {
+                    "nodeType": "list-item",
+                    "content": [
+                      {
+                        "nodeType": "paragraph",
+                        "content": [
+                          {
+                            "nodeType": "text",
+                            "value": "Nr 1",
+                            "marks": [
+                            ],
+                            "data": {
+                            }
+                          }
+                        ],
+                        "data": {
+                        }
+                      }
+                    ],
+                    "data": {
+                    }
+                  },
+                  {
+                    "nodeType": "list-item",
+                    "content": [
+                      {
+                        "nodeType": "paragraph",
+                        "content": [
+                          {
+                            "nodeType": "text",
+                            "value": "Nr 2",
+                            "marks": [
+                            ],
+                            "data": {
+                            }
+                          }
+                        ],
+                        "data": {
+                        }
+                      }
+                    ],
+                    "data": {
+                    }
+                  },
+                  {
+                    "nodeType": "list-item",
+                    "content": [
+                      {
+                        "nodeType": "paragraph",
+                        "content": [
+                          {
+                            "nodeType": "text",
+                            "value": "Nr 3",
+                            "marks": [
+                            ],
+                            "data": {
+                            }
+                          }
+                        ],
+                        "data": {
+                        }
+                      }
+                    ],
+                    "data": {
+                    }
+                  }
+                ],
+                "data": {
+                }
+              },
+              {
+                "nodeType": "paragraph",
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "HR coming",
+                    "marks": [
+                    ],
+                    "data": {
+                    }
+                  }
+                ],
+                "data": {
+                }
+              },
+              {
+                "nodeType": "embedded-asset-block",
+                "content": [
+                ],
+                "data": {
+                  "target": {
+                    "sys": {
+                      "id": "7wWzFZClWaKvhTxh0pC9ps",
+                      "type": "Link",
+                      "linkType": "Asset"
+                    }
+                  }
+                }
+              },
+              {
+                "nodeType": "paragraph",
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "",
+                    "marks": [
+                    ],
+                    "data": {
+                    }
+                  }
+                ],
+                "data": {
+                }
+              },
+              {
+                "nodeType": "paragraph",
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "",
+                    "marks": [
+                    ],
+                    "data": {
+                    }
+                  }
+                ],
+                "data": {
+                }
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "assets": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "6Od9v3wzLOysiMum0Wkmme",
+        "type": "Asset",
+        "createdAt": "2019-05-06T13:06:28.375Z",
+        "updatedAt": "2019-05-06T13:06:33.353Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 2,
+        "publishedAt": "2019-05-06T13:06:33.353Z",
+        "firstPublishedAt": "2019-05-06T13:06:33.353Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 3,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Woman with black hat"
+        },
+        "description": {
+          "en-US": "Woman wearing a black hat"
+        },
+        "file": {
+          "en-US": {
+            "url": "//images.ctfassets.net/x2j9oc2f28ow/6Od9v3wzLOysiMum0Wkmme/683bf4b5de422ed9a29e66e0fc4604ca/cameron-kirby-88711.jpg",
+            "details": {
+              "size": 7316629,
+              "image": {
+                "width": 3000,
+                "height": 2000
+              }
+            },
+            "fileName": "cameron-kirby-88711.jpg",
+            "contentType": "image/jpeg"
+          }
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "7orLdboQQowIUs22KAW4U",
+        "type": "Asset",
+        "createdAt": "2019-05-06T13:06:28.379Z",
+        "updatedAt": "2019-05-06T13:06:33.352Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 2,
+        "publishedAt": "2019-05-06T13:06:33.352Z",
+        "firstPublishedAt": "2019-05-06T13:06:33.352Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 3,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Sparkler"
+        },
+        "description": {
+          "en-US": "John with Sparkler"
+        },
+        "file": {
+          "en-US": {
+            "url": "//images.ctfassets.net/x2j9oc2f28ow/7orLdboQQowIUs22KAW4U/7781b3d7ea651768d2a6eac6e65b2bcd/matt-palmer-254999.jpg",
+            "details": {
+              "size": 2293094,
+              "image": {
+                "width": 3000,
+                "height": 2000
+              }
+            },
+            "fileName": "matt-palmer-254999.jpg",
+            "contentType": "image/jpeg"
+          }
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "4NzwDSDlGECGIiokKomsyI",
+        "type": "Asset",
+        "createdAt": "2019-05-06T13:06:28.382Z",
+        "updatedAt": "2019-05-06T13:06:33.458Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 2,
+        "publishedAt": "2019-05-06T13:06:33.458Z",
+        "firstPublishedAt": "2019-05-06T13:06:33.458Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 3,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "City"
+        },
+        "description": {
+          "en-US": "City pictured from the sky"
+        },
+        "file": {
+          "en-US": {
+            "url": "//images.ctfassets.net/x2j9oc2f28ow/4NzwDSDlGECGIiokKomsyI/e1ad3c13133f35d2134ad2285b926702/denys-nevozhai-100695.jpg",
+            "details": {
+              "size": 15736986,
+              "image": {
+                "width": 3992,
+                "height": 2992
+              }
+            },
+            "fileName": "denys-nevozhai-100695.jpg",
+            "contentType": "image/jpeg"
+          }
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "4shwYI3POEGkw0Eg6kcyaQ",
+        "type": "Asset",
+        "createdAt": "2019-05-06T13:06:28.393Z",
+        "updatedAt": "2019-05-06T13:06:33.381Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 2,
+        "publishedAt": "2019-05-06T13:06:33.381Z",
+        "firstPublishedAt": "2019-05-06T13:06:33.381Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 3,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Man in the fields"
+        },
+        "description": {
+          "en-US": "Tattooed man walking in a field"
+        },
+        "file": {
+          "en-US": {
+            "url": "//images.ctfassets.net/x2j9oc2f28ow/4shwYI3POEGkw0Eg6kcyaQ/fc7101c4cd83bd4baa6e1ff5ffd21d1b/felix-russell-saw-112140.jpg",
+            "details": {
+              "size": 4539181,
+              "image": {
+                "width": 2500,
+                "height": 1667
+              }
+            },
+            "fileName": "felix-russell-saw-112140.jpg",
+            "contentType": "image/jpeg"
+          }
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "7wWzFZClWaKvhTxh0pC9ps",
+        "type": "Asset",
+        "createdAt": "2020-06-24T16:36:15.564Z",
+        "updatedAt": "2020-06-24T16:37:23.290Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 5,
+        "publishedAt": "2020-06-24T16:37:23.290Z",
+        "firstPublishedAt": "2020-06-24T16:37:23.290Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 6,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Unpublished asset"
+        },
+        "description": {
+          "en-US": "This is not published!"
+        },
+        "file": {
+          "en-US": {
+            "url": "//images.ctfassets.net/x2j9oc2f28ow/7wWzFZClWaKvhTxh0pC9ps/fd643f5dd9f0e43e846d971824ae1a9c/1280px-Trollstigen_Norway_2004.jpg",
+            "details": {
+              "size": 549375,
+              "image": {
+                "width": 1280,
+                "height": 844
+              }
+            },
+            "fileName": "1280px-Trollstigen_Norway_2004.jpg",
+            "contentType": "image/jpeg"
+          }
+        }
+      }
+    }
+  ],
+  "locales": [
+    {
+      "name": "English (United States)",
+      "code": "en-US",
+      "fallbackCode": null,
+      "default": true,
+      "contentManagementApi": true,
+      "contentDeliveryApi": true,
+      "optional": false,
+      "sys": {
+        "type": "Locale",
+        "id": "5houKx9MbN34ShZCWtXr6u",
+        "version": 1,
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "environment": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Environment",
+            "id": "master"
+          }
+        },
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "createdAt": "2019-05-06T13:06:25Z",
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedAt": "2019-05-06T13:06:25Z"
+      }
+    }
+  ],
+  "webhooks": [
+  ],
+  "roles": [
+  ]
+}

--- a/test/fixtures/richTextData.json
+++ b/test/fixtures/richTextData.json
@@ -1,0 +1,3146 @@
+{
+  "contentTypes": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "blogPost",
+        "type": "ContentType",
+        "createdAt": "2019-05-06T13:06:27.127Z",
+        "updatedAt": "2020-06-22T16:25:54.769Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 5,
+        "publishedAt": "2020-06-22T16:25:54.769Z",
+        "firstPublishedAt": "2019-05-06T13:06:27.619Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 3,
+        "version": 6,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "displayField": "title",
+      "name": "Blog Post",
+      "description": null,
+      "fields": [
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "slug",
+          "name": "Slug",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "heroImage",
+          "name": "Hero Image",
+          "type": "Link",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Asset"
+        },
+        {
+          "id": "description",
+          "name": "Description",
+          "type": "Text",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "body",
+          "name": "Body",
+          "type": "Text",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "author",
+          "name": "Author",
+          "type": "Link",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "linkContentType": ["person"]
+            }
+          ],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Entry"
+        },
+        {
+          "id": "publishDate",
+          "name": "Publish Date",
+          "type": "Date",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "tags",
+          "name": "Tags",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Symbol",
+            "validations": [
+              {
+                "in": ["general", "javascript", "static-sites"]
+              }
+            ]
+          }
+        },
+        {
+          "id": "richBody",
+          "name": "richBody",
+          "type": "RichText",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "nodes": {}
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "person",
+        "type": "ContentType",
+        "createdAt": "2019-05-06T13:06:27.242Z",
+        "updatedAt": "2019-05-06T13:06:27.725Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 1,
+        "publishedAt": "2019-05-06T13:06:27.725Z",
+        "firstPublishedAt": "2019-05-06T13:06:27.725Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 2,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "displayField": "name",
+      "name": "Person",
+      "description": null,
+      "fields": [
+        {
+          "id": "name",
+          "name": "Name",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "company",
+          "name": "Company",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "shortBio",
+          "name": "Short Bio",
+          "type": "Text",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "email",
+          "name": "Email",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "phone",
+          "name": "Phone",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "facebook",
+          "name": "Facebook",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "twitter",
+          "name": "Twitter",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "github",
+          "name": "Github",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "image",
+          "name": "Image",
+          "type": "Link",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Asset"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "richTextTests",
+        "type": "ContentType",
+        "createdAt": "2020-06-19T12:17:08.778Z",
+        "updatedAt": "2020-06-19T15:06:20.284Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 9,
+        "publishedAt": "2020-06-19T15:06:20.284Z",
+        "firstPublishedAt": "2020-06-19T12:17:09.210Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 5,
+        "version": 10,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "displayField": "title",
+      "name": "Rich text tests",
+      "description": "",
+      "fields": [
+        {
+          "id": "title",
+          "name": "title",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "body",
+          "name": "body",
+          "type": "RichText",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "nodes": {}
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "limitedRichText",
+          "name": "Limited rich text",
+          "type": "RichText",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "nodes": {}
+            },
+            {
+              "enabledNodeTypes": [
+                "heading-1",
+                "heading-2",
+                "heading-3",
+                "heading-4",
+                "heading-5",
+                "heading-6",
+                "ordered-list",
+                "unordered-list",
+                "hr",
+                "blockquote",
+                "embedded-asset-block",
+                "embedded-entry-block"
+              ],
+              "message": "Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, asset, and block entry nodes are allowed"
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    }
+  ],
+  "editorInterfaces": [
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "space": {
+          "sys": {
+            "id": "x2j9oc2f28ow",
+            "type": "Link",
+            "linkType": "Space"
+          }
+        },
+        "version": 5,
+        "createdAt": "2019-05-06T13:06:27.750Z",
+        "createdBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "updatedAt": "2020-06-22T16:25:55.431Z",
+        "updatedBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "id": "blogPost",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "title",
+          "widgetId": "singleLine",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "slug",
+          "widgetId": "singleLine",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "heroImage",
+          "widgetId": "assetLinkEditor",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "description",
+          "widgetId": "markdown",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "body",
+          "widgetId": "markdown",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "author",
+          "settings": {
+            "showLinkEntityAction": true,
+            "showCreateEntityAction": true
+          },
+          "widgetId": "entryLinkEditor",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "publishDate",
+          "widgetId": "datePicker",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "tags",
+          "widgetId": "listInput",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "richBody",
+          "widgetId": "richTextEditor",
+          "widgetNamespace": "builtin"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "space": {
+          "sys": {
+            "id": "x2j9oc2f28ow",
+            "type": "Link",
+            "linkType": "Space"
+          }
+        },
+        "version": 1,
+        "createdAt": "2019-05-06T13:06:27.854Z",
+        "createdBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "updatedAt": "2019-05-06T13:06:27.854Z",
+        "updatedBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "id": "person",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "name",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "title",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "company",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "shortBio",
+          "widgetId": "markdown"
+        },
+        {
+          "fieldId": "email",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "phone",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "facebook",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "twitter",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "github",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "image",
+          "widgetId": "assetLinkEditor"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "space": {
+          "sys": {
+            "id": "x2j9oc2f28ow",
+            "type": "Link",
+            "linkType": "Space"
+          }
+        },
+        "version": 10,
+        "createdAt": "2020-06-19T12:17:09.298Z",
+        "createdBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "updatedAt": "2020-06-19T15:06:20.790Z",
+        "updatedBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "id": "richTextTests",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "title",
+          "widgetId": "singleLine",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "body",
+          "widgetId": "richTextEditor",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "limitedRichText",
+          "widgetId": "richTextEditor",
+          "widgetNamespace": "builtin"
+        }
+      ]
+    }
+  ],
+  "entries": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "31TNnjHlfaGUoMOwU0M2og",
+        "type": "Entry",
+        "createdAt": "2019-05-06T13:06:28.845Z",
+        "updatedAt": "2019-05-06T13:06:29.845Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 1,
+        "publishedAt": "2019-05-06T13:06:29.845Z",
+        "firstPublishedAt": "2019-05-06T13:06:29.845Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 2,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "blogPost"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Automate with webhooks"
+        },
+        "slug": {
+          "en-US": "automate-with-webhooks"
+        },
+        "heroImage": {
+          "en-US": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Asset",
+              "id": "4shwYI3POEGkw0Eg6kcyaQ"
+            }
+          }
+        },
+        "description": {
+          "en-US": "Webhooks notify you, another person or system when resources have changed by calling a given HTTP endpoint."
+        },
+        "body": {
+          "en-US": "## What are webhooks?\n\nThe webhooks are used to notify you when content has been changed. Specify a URL, configure your webhook, and we will send an HTTP POST request whenever something happens to your content.\n\n## How do I configure a webhook?\n\nGo to Settings → Webhooks from the navigation bar at the top. From there, hit Add webhook, and you will be directed to your new webhook. Then choose a name, put in the information of your HTTP endpoint (URL and authentication), specify any custom headers and select the types of events that should trigger the webhook.\n\n## Why do I get an old version in the CDA?\n\nAs the delivery API is powered by a CDN network consisting of hundreds of servers distributed across continents, it takes some time (up to a few minutes) to reflect the changes to the published content. This must be taken into consideration when reacting to webhooks. In normal conditions, there could be a reasonable delay of 2 to 5 minutes.\n\nExtracted from the [Webhooks FAQ](https://www.contentful.com/faq/webhooks/ \"Webhooks FAQ\")."
+        },
+        "author": {
+          "en-US": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Entry",
+              "id": "15jwOBqpxqSAOy2eOO4S0m"
+            }
+          }
+        },
+        "publishDate": {
+          "en-US": "2017-05-12T00:00+02:00"
+        },
+        "tags": {
+          "en-US": ["javascript"]
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "15jwOBqpxqSAOy2eOO4S0m",
+        "type": "Entry",
+        "createdAt": "2019-05-06T13:06:28.945Z",
+        "updatedAt": "2019-05-06T13:06:30.249Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 1,
+        "publishedAt": "2019-05-06T13:06:30.249Z",
+        "firstPublishedAt": "2019-05-06T13:06:30.249Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 2,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "person"
+          }
+        }
+      },
+      "fields": {
+        "name": {
+          "en-US": "John Doe"
+        },
+        "title": {
+          "en-US": "Web Developer"
+        },
+        "company": {
+          "en-US": "ACME"
+        },
+        "shortBio": {
+          "en-US": "Research and recommendations for modern stack websites."
+        },
+        "email": {
+          "en-US": "john@doe.com"
+        },
+        "phone": {
+          "en-US": "0176 / 1234567"
+        },
+        "facebook": {
+          "en-US": "johndoe"
+        },
+        "twitter": {
+          "en-US": "johndoe"
+        },
+        "github": {
+          "en-US": "johndoe"
+        },
+        "image": {
+          "en-US": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Asset",
+              "id": "7orLdboQQowIUs22KAW4U"
+            }
+          }
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "2PtC9h1YqIA6kaUaIsWEQ0",
+        "type": "Entry",
+        "createdAt": "2019-05-06T13:06:28.948Z",
+        "updatedAt": "2019-05-06T13:06:29.853Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 1,
+        "publishedAt": "2019-05-06T13:06:29.853Z",
+        "firstPublishedAt": "2019-05-06T13:06:29.853Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 2,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "blogPost"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Static sites are great"
+        },
+        "slug": {
+          "en-US": "static-sites-are-great"
+        },
+        "heroImage": {
+          "en-US": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Asset",
+              "id": "4NzwDSDlGECGIiokKomsyI"
+            }
+          }
+        },
+        "description": {
+          "en-US": "Worry less about security, caching, and talking to the server. Static sites are the new thing."
+        },
+        "body": {
+          "en-US": "## The case for the static site generator\n\nMore and more developers are jumping on the \"go static train\", and rightfully so. Static pages are fast, lightweight, they scale well. They are more secure, and simple to maintain and they allow you to focus all your time and effort on the user interface. Often times, this dedication really shows.\n\nIt just so happens that static site generators are mostly loved by developers, but not by the average Joe. They do not offer WYSIWYG, previewing on demo sites may take an update cycle, they are often based on markdown text files, and they require some knowledge of modern day repositories.\n\nMoreover, when teams are collaborating, it can get complicated quickly. Has this article already been proof-read or reviewed? Is this input valid? Are user permissions available, e.g. for administering adding and removing team members? Can this article be published at a future date? How can a large repository of content be categorized, organized, and searched? All these requirements have previously been more or less solved within the admin area of your CMS. But of course with all the baggage that made you leave the appserver-app-database-in-one-big-blob stack in the first place.\n\n## Content APIs to the rescue\n\nAn alternative is decoupling the content management aspect from the system. And then replacing the maintenance prone server with a cloud based web service offering. Effectively, instead of your CMS of old, you move to a [Content Management as a Service (CMaaS)](https://www.contentful.com/r/knowledgebase/content-as-a-service/ \"Content Management as a Service (CMaaS)\") world, with a content API to deliver all your content. That way, you get the all the [benefits of content management features](http://www.digett.com/blog/01/16/2014/pairing-static-websites-cms \"benefits of content management features\") while still being able to embrace the static site generator mantra.\n\nIt so happens that Contentful is offering just that kind of content API. A service that\n\n* from the ground up has been designed to be fast, scalable, secure, and offer high uptime, so that you don’t have to worry about maintenance ever again.\n* offers a powerful editor and lots of flexibility in creating templates for your documents that your editors can reuse and combine, so that no developers resources are required in everyday writing and updating tasks.\n* separates content from presentation, so you can reuse your content repository for any device platform your heart desires. That way, you can COPE (\"create once, publish everywhere\").\n* offers webhooks that you can use to rebuild your static site in a fully automated fashion every time your content is modified.\n\nExtracted from the article [CMS-functionality for static site generators](https://www.contentful.com/r/knowledgebase/contentful-api-cms-static-site-generators/ \"CMS-functionality for static site generators\"). Read more about the [static site generators supported by Contentful](https://www.contentful.com/developers/docs/tools/staticsitegenerators/ \"static site generators supported by Contentful\")."
+        },
+        "author": {
+          "en-US": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Entry",
+              "id": "15jwOBqpxqSAOy2eOO4S0m"
+            }
+          }
+        },
+        "publishDate": {
+          "en-US": "2017-05-16T00:00+02:00"
+        },
+        "tags": {
+          "en-US": ["javascript", "static-sites"]
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "3K9b0esdy0q0yGqgW2g6Ke",
+        "type": "Entry",
+        "createdAt": "2019-05-06T13:06:29.269Z",
+        "updatedAt": "2019-05-06T13:06:30.622Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 1,
+        "publishedAt": "2019-05-06T13:06:30.622Z",
+        "firstPublishedAt": "2019-05-06T13:06:30.622Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 2,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "blogPost"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Hello world"
+        },
+        "slug": {
+          "en-US": "hello-world"
+        },
+        "heroImage": {
+          "en-US": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Asset",
+              "id": "6Od9v3wzLOysiMum0Wkmme"
+            }
+          }
+        },
+        "description": {
+          "en-US": "Your very first content with Contentful, pulled in JSON format using the Content Delivery API."
+        },
+        "body": {
+          "en-US": "These is your very first content with Contentful, pulled in JSON format using the [Content Delivery API](https://www.contentful.com/developers/docs/references/content-delivery-api/ \"Content Delivery API\"). Content and presentation are now decoupled, allowing you to focus your efforts in building the perfect app.\n\n## Your first steps\n\nBuilding with Contentful is easy. First take a moment to get [the basics of content modelling](https://www.contentful.com/r/knowledgebase/content-modelling-basics/ \"the basics of content modelling\"), which you can set up in the [Contentful Web app](https://app.contentful.com/ \"Contentful Web app\"). Once you get that, feel free to drop by the [Documentation](https://www.contentful.com/developers/docs/ \"Documentation\") to learn a bit more about how to build your app with Contentful, in particular the [API basics](https://www.contentful.com/developers/docs/concepts/apis/ \"API basics\") and each one of our four APIs, as shown below.\n\n### Content Delivery API\n\nThe [Content Delivery API](https://www.contentful.com/developers/docs/references/content-delivery-api/ \"Content Delivery API\") (CDA), available at `cdn.contentful.com`, is a read-only API for delivering content from Contentful to apps, websites and other media. Content is delivered as JSON data, and images, videos and other media as files.\nThe API is available via a globally distributed content delivery network. The server closest to the user serves all content, both JSON and binary. This minimizes latency, which especially benefits mobile apps. Hosting content in multiple global data centers also greatly improves the availability of content.\n\n### Content Management API\n\nThe [Content Management API](https://www.contentful.com/developers/docs/references/content-management-api/ \"Content Management API\") (CMA), available at `api.contentful.com`, is a read-write API for managing content. Unlike the Content Delivery API, the management API requires you to authenticate as a Contentful user. You could use the CMA for several use cases, such as:\n* Automatic imports from different CMSes like WordPress or Drupal.\n* Integration with other backend systems, such as an e-commerce shop.\n* Building custom editing experiences. We built the [Contentful Web app](https://app.contentful.com/ \"Contentful Web app\") on top of this API.\n\n### Preview API\n\nThe [Content Preview API](https://www.contentful.com/developers/docs/concepts/apis/#content-preview-api \"Content Preview API\"), available at `preview.contentful.com`, is a variant of the CDA for previewing your content before delivering it to your customers. You use the Content Preview API in combination with a \"preview\" deployment of your website (or a \"preview\" build of your mobile app) that allows content managers and authors to view their work in-context, as if it were published, using a \"preview\" access token as though it were delivered by the CDA.\n\n### Images API\n\nThe [Images API](https://www.contentful.com/developers/docs/concepts/apis/#images-api \"Images API\"), available at `images.contentful.com`, allows you to resize and crop images, change their background color and convert them to different formats. Using our API for these transformations lets you upload high-quality assets, deliver exactly what your app needs, and still get all the benefits of our caching CDN."
+        },
+        "author": {
+          "en-US": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Entry",
+              "id": "15jwOBqpxqSAOy2eOO4S0m"
+            }
+          }
+        },
+        "publishDate": {
+          "en-US": "2017-05-15T00:00+02:00"
+        },
+        "tags": {
+          "en-US": ["general"]
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "6srGkkKcZhVb1mz0m7OHgE",
+        "type": "Entry",
+        "createdAt": "2020-06-18T18:57:47.927Z",
+        "updatedAt": "2020-06-18T19:11:33.269Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 0,
+        "version": 88,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "blogPost"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "This is a draft"
+        },
+        "slug": {
+          "en-US": "draft-blog-post"
+        },
+        "heroImage": {
+          "en-US": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Asset",
+              "id": "4NzwDSDlGECGIiokKomsyI"
+            }
+          }
+        },
+        "description": {
+          "en-US": "This my description. I think its __markdown__"
+        },
+        "body": {
+          "en-US": "First paragraph in the body field.\n\nAnother one with __bold__, *italics*"
+        },
+        "publishDate": {
+          "en-US": "2020-06-18T00:00+02:00"
+        },
+        "tags": {
+          "en-US": ["general", "javascript"]
+        },
+        "richBody": {
+          "en-US": {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "Heading1",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "heading-1"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "Heading2",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "heading-2"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "Heading3",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "heading-3"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "Heading4",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "heading-4"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "Heading5",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "heading-5"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "Heading6",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "heading-6"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "This is a paragraph standing by itself. It has ",
+                    "nodeType": "text"
+                  },
+                  {
+                    "data": {},
+                    "marks": [
+                      {
+                        "type": "bold"
+                      }
+                    ],
+                    "value": "bold",
+                    "nodeType": "text"
+                  },
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": ", ",
+                    "nodeType": "text"
+                  },
+                  {
+                    "data": {},
+                    "marks": [
+                      {
+                        "type": "italic"
+                      }
+                    ],
+                    "value": "italics",
+                    "nodeType": "text"
+                  },
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": ", ",
+                    "nodeType": "text"
+                  },
+                  {
+                    "data": {},
+                    "marks": [
+                      {
+                        "type": "underline"
+                      }
+                    ],
+                    "value": "underline",
+                    "nodeType": "text"
+                  },
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": " and ",
+                    "nodeType": "text"
+                  },
+                  {
+                    "data": {},
+                    "marks": [
+                      {
+                        "type": "code"
+                      }
+                    ],
+                    "value": "code",
+                    "nodeType": "text"
+                  },
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": ".",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "This next paragraph has ",
+                    "nodeType": "text"
+                  },
+                  {
+                    "data": {},
+                    "marks": [
+                      {
+                        "type": "bold"
+                      },
+                      {
+                        "type": "italic"
+                      },
+                      {
+                        "type": "underline"
+                      },
+                      {
+                        "type": "code"
+                      }
+                    ],
+                    "value": "bolditalicsunderlinecode",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "Third paragraph has a ",
+                    "nodeType": "text"
+                  },
+                  {
+                    "data": {
+                      "uri": "https://www.nrk.no"
+                    },
+                    "content": [
+                      {
+                        "data": {},
+                        "marks": [],
+                        "value": "URL Link",
+                        "nodeType": "text"
+                      }
+                    ],
+                    "nodeType": "hyperlink"
+                  },
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "Fourth paragraph goes with an ",
+                    "nodeType": "text"
+                  },
+                  {
+                    "data": {
+                      "target": {
+                        "sys": {
+                          "id": "15jwOBqpxqSAOy2eOO4S0m",
+                          "type": "Link",
+                          "linkType": "Entry"
+                        }
+                      }
+                    },
+                    "content": [
+                      {
+                        "data": {},
+                        "marks": [],
+                        "value": "Entry link to Person",
+                        "nodeType": "text"
+                      }
+                    ],
+                    "nodeType": "entry-hyperlink"
+                  },
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "Fifth paragraph does an ",
+                    "nodeType": "text"
+                  },
+                  {
+                    "data": {
+                      "target": {
+                        "sys": {
+                          "id": "4shwYI3POEGkw0Eg6kcyaQ",
+                          "type": "Link",
+                          "linkType": "Asset"
+                        }
+                      }
+                    },
+                    "content": [
+                      {
+                        "data": {},
+                        "marks": [],
+                        "value": "Asset link",
+                        "nodeType": "text"
+                      }
+                    ],
+                    "nodeType": "asset-hyperlink"
+                  },
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              },
+              {
+                "data": {},
+                "content": [],
+                "nodeType": "hr"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "Next up is an embedded Entry, a blog post reference. I think its outside this current paragraph?",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              },
+              {
+                "data": {
+                  "target": {
+                    "sys": {
+                      "id": "3K9b0esdy0q0yGqgW2g6Ke",
+                      "type": "Link",
+                      "linkType": "Entry"
+                    }
+                  }
+                },
+                "content": [],
+                "nodeType": "embedded-entry-block"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "Then maybe lets try a quote",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "content": [
+                      {
+                        "data": {},
+                        "marks": [],
+                        "value": "My block quote has arrived",
+                        "nodeType": "text"
+                      }
+                    ],
+                    "nodeType": "paragraph"
+                  },
+                  {
+                    "data": {},
+                    "content": [
+                      {
+                        "data": {},
+                        "marks": [],
+                        "value": "- Mark Twain",
+                        "nodeType": "text"
+                      }
+                    ],
+                    "nodeType": "paragraph"
+                  }
+                ],
+                "nodeType": "blockquote"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "content": [
+                      {
+                        "data": {},
+                        "content": [
+                          {
+                            "data": {},
+                            "marks": [],
+                            "value": "Unordered list first",
+                            "nodeType": "text"
+                          }
+                        ],
+                        "nodeType": "paragraph"
+                      }
+                    ],
+                    "nodeType": "list-item"
+                  },
+                  {
+                    "data": {},
+                    "content": [
+                      {
+                        "data": {},
+                        "content": [
+                          {
+                            "data": {},
+                            "marks": [],
+                            "value": "Unordered list second",
+                            "nodeType": "text"
+                          }
+                        ],
+                        "nodeType": "paragraph"
+                      }
+                    ],
+                    "nodeType": "list-item"
+                  },
+                  {
+                    "data": {},
+                    "content": [
+                      {
+                        "data": {},
+                        "content": [
+                          {
+                            "data": {},
+                            "marks": [],
+                            "value": "Unordered list third",
+                            "nodeType": "text"
+                          }
+                        ],
+                        "nodeType": "paragraph"
+                      },
+                      {
+                        "data": {},
+                        "content": [
+                          {
+                            "data": {},
+                            "content": [
+                              {
+                                "data": {},
+                                "content": [
+                                  {
+                                    "data": {},
+                                    "marks": [],
+                                    "value": "Nested unordered first",
+                                    "nodeType": "text"
+                                  }
+                                ],
+                                "nodeType": "paragraph"
+                              }
+                            ],
+                            "nodeType": "list-item"
+                          },
+                          {
+                            "data": {},
+                            "content": [
+                              {
+                                "data": {},
+                                "content": [
+                                  {
+                                    "data": {},
+                                    "marks": [],
+                                    "value": "Nested unordered second",
+                                    "nodeType": "text"
+                                  }
+                                ],
+                                "nodeType": "paragraph"
+                              },
+                              {
+                                "data": {},
+                                "content": [
+                                  {
+                                    "data": {},
+                                    "content": [
+                                      {
+                                        "data": {},
+                                        "content": [
+                                          {
+                                            "data": {},
+                                            "marks": [],
+                                            "value": "third level nesting first",
+                                            "nodeType": "text"
+                                          }
+                                        ],
+                                        "nodeType": "paragraph"
+                                      }
+                                    ],
+                                    "nodeType": "list-item"
+                                  },
+                                  {
+                                    "data": {},
+                                    "content": [
+                                      {
+                                        "data": {},
+                                        "content": [
+                                          {
+                                            "data": {},
+                                            "marks": [],
+                                            "value": "third level nesting second",
+                                            "nodeType": "text"
+                                          }
+                                        ],
+                                        "nodeType": "paragraph"
+                                      },
+                                      {
+                                        "data": {},
+                                        "content": [
+                                          {
+                                            "data": {},
+                                            "content": [
+                                              {
+                                                "data": {},
+                                                "content": [
+                                                  {
+                                                    "data": {},
+                                                    "marks": [],
+                                                    "value": "fourth level nesting",
+                                                    "nodeType": "text"
+                                                  }
+                                                ],
+                                                "nodeType": "paragraph"
+                                              },
+                                              {
+                                                "data": {},
+                                                "content": [
+                                                  {
+                                                    "data": {},
+                                                    "content": [
+                                                      {
+                                                        "data": {},
+                                                        "content": [
+                                                          {
+                                                            "data": {},
+                                                            "marks": [],
+                                                            "value": "fifth level nesting",
+                                                            "nodeType": "text"
+                                                          }
+                                                        ],
+                                                        "nodeType": "paragraph"
+                                                      },
+                                                      {
+                                                        "data": {},
+                                                        "content": [
+                                                          {
+                                                            "data": {},
+                                                            "content": [
+                                                              {
+                                                                "data": {},
+                                                                "content": [
+                                                                  {
+                                                                    "data": {},
+                                                                    "marks": [],
+                                                                    "value": "sixth level nesting",
+                                                                    "nodeType": "text"
+                                                                  }
+                                                                ],
+                                                                "nodeType": "paragraph"
+                                                              }
+                                                            ],
+                                                            "nodeType": "list-item"
+                                                          },
+                                                          {
+                                                            "data": {},
+                                                            "content": [
+                                                              {
+                                                                "data": {},
+                                                                "content": [
+                                                                  {
+                                                                    "data": {},
+                                                                    "marks": [],
+                                                                    "value": "And we can nest no more",
+                                                                    "nodeType": "text"
+                                                                  }
+                                                                ],
+                                                                "nodeType": "paragraph"
+                                                              }
+                                                            ],
+                                                            "nodeType": "list-item"
+                                                          }
+                                                        ],
+                                                        "nodeType": "unordered-list"
+                                                      },
+                                                      {
+                                                        "data": {},
+                                                        "content": [
+                                                          {
+                                                            "data": {},
+                                                            "marks": [],
+                                                            "value": "",
+                                                            "nodeType": "text"
+                                                          }
+                                                        ],
+                                                        "nodeType": "paragraph"
+                                                      }
+                                                    ],
+                                                    "nodeType": "list-item"
+                                                  }
+                                                ],
+                                                "nodeType": "unordered-list"
+                                              },
+                                              {
+                                                "data": {},
+                                                "content": [
+                                                  {
+                                                    "data": {},
+                                                    "marks": [],
+                                                    "value": "",
+                                                    "nodeType": "text"
+                                                  }
+                                                ],
+                                                "nodeType": "paragraph"
+                                              }
+                                            ],
+                                            "nodeType": "list-item"
+                                          }
+                                        ],
+                                        "nodeType": "unordered-list"
+                                      },
+                                      {
+                                        "data": {},
+                                        "content": [
+                                          {
+                                            "data": {},
+                                            "marks": [],
+                                            "value": "",
+                                            "nodeType": "text"
+                                          }
+                                        ],
+                                        "nodeType": "paragraph"
+                                      }
+                                    ],
+                                    "nodeType": "list-item"
+                                  }
+                                ],
+                                "nodeType": "unordered-list"
+                              },
+                              {
+                                "data": {},
+                                "content": [
+                                  {
+                                    "data": {},
+                                    "marks": [],
+                                    "value": "",
+                                    "nodeType": "text"
+                                  }
+                                ],
+                                "nodeType": "paragraph"
+                              }
+                            ],
+                            "nodeType": "list-item"
+                          }
+                        ],
+                        "nodeType": "unordered-list"
+                      },
+                      {
+                        "data": {},
+                        "content": [
+                          {
+                            "data": {},
+                            "marks": [],
+                            "value": "",
+                            "nodeType": "text"
+                          }
+                        ],
+                        "nodeType": "paragraph"
+                      }
+                    ],
+                    "nodeType": "list-item"
+                  }
+                ],
+                "nodeType": "unordered-list"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "content": [
+                      {
+                        "data": {},
+                        "content": [
+                          {
+                            "data": {},
+                            "marks": [],
+                            "value": "Ordered list first (1.)",
+                            "nodeType": "text"
+                          }
+                        ],
+                        "nodeType": "paragraph"
+                      }
+                    ],
+                    "nodeType": "list-item"
+                  },
+                  {
+                    "data": {},
+                    "content": [
+                      {
+                        "data": {},
+                        "content": [
+                          {
+                            "data": {},
+                            "marks": [],
+                            "value": "Ordered list second (2.)",
+                            "nodeType": "text"
+                          }
+                        ],
+                        "nodeType": "paragraph"
+                      },
+                      {
+                        "data": {},
+                        "content": [
+                          {
+                            "data": {},
+                            "content": [
+                              {
+                                "data": {},
+                                "content": [
+                                  {
+                                    "data": {},
+                                    "marks": [],
+                                    "value": "Nested ordered list first (A.)",
+                                    "nodeType": "text"
+                                  }
+                                ],
+                                "nodeType": "paragraph"
+                              }
+                            ],
+                            "nodeType": "list-item"
+                          },
+                          {
+                            "data": {},
+                            "content": [
+                              {
+                                "data": {},
+                                "content": [
+                                  {
+                                    "data": {},
+                                    "marks": [],
+                                    "value": "Nested ordered list second (B.)",
+                                    "nodeType": "text"
+                                  }
+                                ],
+                                "nodeType": "paragraph"
+                              },
+                              {
+                                "data": {},
+                                "content": [
+                                  {
+                                    "data": {},
+                                    "content": [
+                                      {
+                                        "data": {},
+                                        "content": [
+                                          {
+                                            "data": {},
+                                            "marks": [],
+                                            "value": "third level nesting (i.)",
+                                            "nodeType": "text"
+                                          }
+                                        ],
+                                        "nodeType": "paragraph"
+                                      },
+                                      {
+                                        "data": {},
+                                        "content": [
+                                          {
+                                            "data": {},
+                                            "content": [
+                                              {
+                                                "data": {},
+                                                "content": [
+                                                  {
+                                                    "data": {},
+                                                    "marks": [],
+                                                    "value": "fourth level nesting (a.)",
+                                                    "nodeType": "text"
+                                                  }
+                                                ],
+                                                "nodeType": "paragraph"
+                                              },
+                                              {
+                                                "data": {},
+                                                "content": [
+                                                  {
+                                                    "data": {},
+                                                    "content": [
+                                                      {
+                                                        "data": {},
+                                                        "content": [
+                                                          {
+                                                            "data": {},
+                                                            "marks": [],
+                                                            "value": "fifth (a.)",
+                                                            "nodeType": "text"
+                                                          }
+                                                        ],
+                                                        "nodeType": "paragraph"
+                                                      },
+                                                      {
+                                                        "data": {},
+                                                        "content": [
+                                                          {
+                                                            "data": {},
+                                                            "content": [
+                                                              {
+                                                                "data": {},
+                                                                "content": [
+                                                                  {
+                                                                    "data": {},
+                                                                    "marks": [],
+                                                                    "value": "sixth (a.)",
+                                                                    "nodeType": "text"
+                                                                  }
+                                                                ],
+                                                                "nodeType": "paragraph"
+                                                              }
+                                                            ],
+                                                            "nodeType": "list-item"
+                                                          },
+                                                          {
+                                                            "data": {},
+                                                            "content": [
+                                                              {
+                                                                "data": {},
+                                                                "content": [
+                                                                  {
+                                                                    "data": {},
+                                                                    "marks": [],
+                                                                    "value": "And we can nest no more",
+                                                                    "nodeType": "text"
+                                                                  }
+                                                                ],
+                                                                "nodeType": "paragraph"
+                                                              }
+                                                            ],
+                                                            "nodeType": "list-item"
+                                                          }
+                                                        ],
+                                                        "nodeType": "ordered-list"
+                                                      },
+                                                      {
+                                                        "data": {},
+                                                        "content": [
+                                                          {
+                                                            "data": {},
+                                                            "marks": [],
+                                                            "value": "",
+                                                            "nodeType": "text"
+                                                          }
+                                                        ],
+                                                        "nodeType": "paragraph"
+                                                      }
+                                                    ],
+                                                    "nodeType": "list-item"
+                                                  }
+                                                ],
+                                                "nodeType": "ordered-list"
+                                              },
+                                              {
+                                                "data": {},
+                                                "content": [
+                                                  {
+                                                    "data": {},
+                                                    "marks": [],
+                                                    "value": "",
+                                                    "nodeType": "text"
+                                                  }
+                                                ],
+                                                "nodeType": "paragraph"
+                                              }
+                                            ],
+                                            "nodeType": "list-item"
+                                          }
+                                        ],
+                                        "nodeType": "ordered-list"
+                                      },
+                                      {
+                                        "data": {},
+                                        "content": [
+                                          {
+                                            "data": {},
+                                            "marks": [],
+                                            "value": "",
+                                            "nodeType": "text"
+                                          }
+                                        ],
+                                        "nodeType": "paragraph"
+                                      }
+                                    ],
+                                    "nodeType": "list-item"
+                                  }
+                                ],
+                                "nodeType": "ordered-list"
+                              },
+                              {
+                                "data": {},
+                                "content": [
+                                  {
+                                    "data": {},
+                                    "marks": [],
+                                    "value": "",
+                                    "nodeType": "text"
+                                  }
+                                ],
+                                "nodeType": "paragraph"
+                              }
+                            ],
+                            "nodeType": "list-item"
+                          }
+                        ],
+                        "nodeType": "ordered-list"
+                      },
+                      {
+                        "data": {},
+                        "content": [
+                          {
+                            "data": {},
+                            "marks": [],
+                            "value": "",
+                            "nodeType": "text"
+                          }
+                        ],
+                        "nodeType": "paragraph"
+                      }
+                    ],
+                    "nodeType": "list-item"
+                  }
+                ],
+                "nodeType": "ordered-list"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "This paragraph has an inline entry at the next word",
+                    "nodeType": "text"
+                  },
+                  {
+                    "data": {
+                      "target": {
+                        "sys": {
+                          "id": "15jwOBqpxqSAOy2eOO4S0m",
+                          "type": "Link",
+                          "linkType": "Entry"
+                        }
+                      }
+                    },
+                    "content": [],
+                    "nodeType": "embedded-entry-inline"
+                  },
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "- Now we are past it.",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "content": [
+                      {
+                        "data": {},
+                        "content": [
+                          {
+                            "data": {},
+                            "marks": [],
+                            "value": "Inline entry in numbered list comes now ",
+                            "nodeType": "text"
+                          },
+                          {
+                            "data": {
+                              "target": {
+                                "sys": {
+                                  "id": "3K9b0esdy0q0yGqgW2g6Ke",
+                                  "type": "Link",
+                                  "linkType": "Entry"
+                                }
+                              }
+                            },
+                            "content": [],
+                            "nodeType": "embedded-entry-inline"
+                          },
+                          {
+                            "data": {},
+                            "marks": [],
+                            "value": "",
+                            "nodeType": "text"
+                          }
+                        ],
+                        "nodeType": "paragraph"
+                      }
+                    ],
+                    "nodeType": "list-item"
+                  },
+                  {
+                    "data": {},
+                    "content": [
+                      {
+                        "data": {},
+                        "content": [
+                          {
+                            "data": {},
+                            "marks": [],
+                            "value": "And lest try an asset entry in the list item nr 2: ",
+                            "nodeType": "text"
+                          }
+                        ],
+                        "nodeType": "paragraph"
+                      },
+                      {
+                        "data": {
+                          "target": {
+                            "sys": {
+                              "id": "4NzwDSDlGECGIiokKomsyI",
+                              "type": "Link",
+                              "linkType": "Asset"
+                            }
+                          }
+                        },
+                        "content": [],
+                        "nodeType": "embedded-asset-block"
+                      },
+                      {
+                        "data": {},
+                        "content": [
+                          {
+                            "data": {},
+                            "marks": [],
+                            "value": "",
+                            "nodeType": "text"
+                          }
+                        ],
+                        "nodeType": "paragraph"
+                      }
+                    ],
+                    "nodeType": "list-item"
+                  },
+                  {
+                    "data": {},
+                    "content": [
+                      {
+                        "data": {},
+                        "content": [
+                          {
+                            "data": {},
+                            "marks": [],
+                            "value": "Now we're on the third item",
+                            "nodeType": "text"
+                          }
+                        ],
+                        "nodeType": "paragraph"
+                      }
+                    ],
+                    "nodeType": "list-item"
+                  }
+                ],
+                "nodeType": "ordered-list"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "document"
+          }
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "5gC5EqwZNAtDvTIVHYAIji",
+        "type": "Entry",
+        "createdAt": "2020-06-19T12:17:21.444Z",
+        "updatedAt": "2020-06-19T12:18:58.371Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 6,
+        "publishedAt": "2020-06-19T12:18:13.366Z",
+        "firstPublishedAt": "2020-06-19T12:18:13.366Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 8,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "richTextTests"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Line item inline entry"
+        },
+        "body": {
+          "en-US": {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "content": [
+                      {
+                        "data": {},
+                        "content": [
+                          {
+                            "data": {},
+                            "marks": [],
+                            "value": "I have an inline entry: ",
+                            "nodeType": "text"
+                          },
+                          {
+                            "data": {
+                              "target": {
+                                "sys": {
+                                  "id": "15jwOBqpxqSAOy2eOO4S0m",
+                                  "type": "Link",
+                                  "linkType": "Entry"
+                                }
+                              }
+                            },
+                            "content": [],
+                            "nodeType": "embedded-entry-inline"
+                          },
+                          {
+                            "data": {},
+                            "marks": [],
+                            "value": ". EOM.",
+                            "nodeType": "text"
+                          }
+                        ],
+                        "nodeType": "paragraph"
+                      }
+                    ],
+                    "nodeType": "list-item"
+                  }
+                ],
+                "nodeType": "unordered-list"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "document"
+          }
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "6FFP88uWOKo2mKv4fbdXWz",
+        "type": "Entry",
+        "createdAt": "2020-06-19T12:18:24.854Z",
+        "updatedAt": "2020-06-19T12:19:38.330Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 6,
+        "publishedAt": "2020-06-19T12:19:38.330Z",
+        "firstPublishedAt": "2020-06-19T12:19:38.330Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 7,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "richTextTests"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Numbered list with asset in line item 1"
+        },
+        "body": {
+          "en-US": {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "content": [
+                      {
+                        "data": {},
+                        "content": [
+                          {
+                            "data": {},
+                            "marks": [],
+                            "value": "Asset in numbered line item here ",
+                            "nodeType": "text"
+                          }
+                        ],
+                        "nodeType": "paragraph"
+                      },
+                      {
+                        "data": {
+                          "target": {
+                            "sys": {
+                              "id": "4shwYI3POEGkw0Eg6kcyaQ",
+                              "type": "Link",
+                              "linkType": "Asset"
+                            }
+                          }
+                        },
+                        "content": [],
+                        "nodeType": "embedded-asset-block"
+                      },
+                      {
+                        "data": {},
+                        "content": [
+                          {
+                            "data": {},
+                            "marks": [],
+                            "value": "",
+                            "nodeType": "text"
+                          }
+                        ],
+                        "nodeType": "paragraph"
+                      }
+                    ],
+                    "nodeType": "list-item"
+                  },
+                  {
+                    "data": {},
+                    "content": [
+                      {
+                        "data": {},
+                        "content": [
+                          {
+                            "data": {},
+                            "marks": [],
+                            "value": "Second line item",
+                            "nodeType": "text"
+                          }
+                        ],
+                        "nodeType": "paragraph"
+                      }
+                    ],
+                    "nodeType": "list-item"
+                  }
+                ],
+                "nodeType": "ordered-list"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "document"
+          }
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "474jVxwDdvpwo06lqlGuq2",
+        "type": "Entry",
+        "createdAt": "2020-06-19T12:19:52.704Z",
+        "updatedAt": "2020-06-19T12:20:26.216Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 5,
+        "publishedAt": "2020-06-19T12:20:26.216Z",
+        "firstPublishedAt": "2020-06-19T12:20:26.216Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 6,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "richTextTests"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Ordered list with Entry embedded in line item 1"
+        },
+        "body": {
+          "en-US": {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "content": [
+                      {
+                        "data": {},
+                        "content": [
+                          {
+                            "data": {},
+                            "marks": [],
+                            "value": "Entry in here ",
+                            "nodeType": "text"
+                          }
+                        ],
+                        "nodeType": "paragraph"
+                      },
+                      {
+                        "data": {
+                          "target": {
+                            "sys": {
+                              "id": "3K9b0esdy0q0yGqgW2g6Ke",
+                              "type": "Link",
+                              "linkType": "Entry"
+                            }
+                          }
+                        },
+                        "content": [],
+                        "nodeType": "embedded-entry-block"
+                      },
+                      {
+                        "data": {},
+                        "content": [
+                          {
+                            "data": {},
+                            "marks": [],
+                            "value": "",
+                            "nodeType": "text"
+                          }
+                        ],
+                        "nodeType": "paragraph"
+                      }
+                    ],
+                    "nodeType": "list-item"
+                  },
+                  {
+                    "data": {},
+                    "content": [
+                      {
+                        "data": {},
+                        "content": [
+                          {
+                            "data": {},
+                            "marks": [],
+                            "value": "Second line item",
+                            "nodeType": "text"
+                          }
+                        ],
+                        "nodeType": "paragraph"
+                      }
+                    ],
+                    "nodeType": "list-item"
+                  }
+                ],
+                "nodeType": "ordered-list"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "document"
+          }
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "3tggAg5IiDUJbuVQn5y2Cm",
+        "type": "Entry",
+        "createdAt": "2020-06-19T12:22:18.720Z",
+        "updatedAt": "2020-06-19T15:06:48.430Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 13,
+        "publishedAt": "2020-06-19T15:05:55.175Z",
+        "firstPublishedAt": "2020-06-19T15:04:04.079Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 3,
+        "version": 16,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "richTextTests"
+          }
+        }
+      },
+      "fields": {
+        "body": {
+          "en-US": {
+            "data": {},
+            "content": [
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "A headline with inline entry ",
+                    "nodeType": "text"
+                  },
+                  {
+                    "data": {
+                      "target": {
+                        "sys": {
+                          "id": "15jwOBqpxqSAOy2eOO4S0m",
+                          "type": "Link",
+                          "linkType": "Entry"
+                        }
+                      }
+                    },
+                    "content": [],
+                    "nodeType": "embedded-entry-inline"
+                  },
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "heading-1"
+              },
+              {
+                "data": {},
+                "content": [
+                  {
+                    "data": {},
+                    "marks": [],
+                    "value": "",
+                    "nodeType": "text"
+                  }
+                ],
+                "nodeType": "paragraph"
+              }
+            ],
+            "nodeType": "document"
+          }
+        },
+        "limitedRichText": {
+          "en-US": {
+            "nodeType": "document",
+            "data": {},
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "Only embeds allowed here are images as blocks. no.",
+                    "marks": [],
+                    "data": {}
+                  }
+                ],
+                "data": {}
+              },
+              {
+                "nodeType": "embedded-entry-block",
+                "content": [],
+                "data": {
+                  "target": {
+                    "sys": {
+                      "id": "474jVxwDdvpwo06lqlGuq2",
+                      "type": "Link",
+                      "linkType": "Entry"
+                    }
+                  }
+                }
+              },
+              {
+                "nodeType": "paragraph",
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "",
+                    "marks": [],
+                    "data": {}
+                  }
+                ],
+                "data": {}
+              },
+              {
+                "nodeType": "embedded-asset-block",
+                "content": [],
+                "data": {
+                  "target": {
+                    "sys": {
+                      "id": "4shwYI3POEGkw0Eg6kcyaQ",
+                      "type": "Link",
+                      "linkType": "Asset"
+                    }
+                  }
+                }
+              },
+              {
+                "nodeType": "paragraph",
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "",
+                    "marks": [],
+                    "data": {}
+                  }
+                ],
+                "data": {}
+              }
+            ]
+          }
+        }
+      }
+    }
+  ],
+  "assets": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "6Od9v3wzLOysiMum0Wkmme",
+        "type": "Asset",
+        "createdAt": "2019-05-06T13:06:28.375Z",
+        "updatedAt": "2019-05-06T13:06:33.353Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 2,
+        "publishedAt": "2019-05-06T13:06:33.353Z",
+        "firstPublishedAt": "2019-05-06T13:06:33.353Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 3,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Woman with black hat"
+        },
+        "description": {
+          "en-US": "Woman wearing a black hat"
+        },
+        "file": {
+          "en-US": {
+            "url": "//images.ctfassets.net/x2j9oc2f28ow/6Od9v3wzLOysiMum0Wkmme/683bf4b5de422ed9a29e66e0fc4604ca/cameron-kirby-88711.jpg",
+            "details": {
+              "size": 7316629,
+              "image": {
+                "width": 3000,
+                "height": 2000
+              }
+            },
+            "fileName": "cameron-kirby-88711.jpg",
+            "contentType": "image/jpeg"
+          }
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "7orLdboQQowIUs22KAW4U",
+        "type": "Asset",
+        "createdAt": "2019-05-06T13:06:28.379Z",
+        "updatedAt": "2019-05-06T13:06:33.352Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 2,
+        "publishedAt": "2019-05-06T13:06:33.352Z",
+        "firstPublishedAt": "2019-05-06T13:06:33.352Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 3,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Sparkler"
+        },
+        "description": {
+          "en-US": "John with Sparkler"
+        },
+        "file": {
+          "en-US": {
+            "url": "//images.ctfassets.net/x2j9oc2f28ow/7orLdboQQowIUs22KAW4U/7781b3d7ea651768d2a6eac6e65b2bcd/matt-palmer-254999.jpg",
+            "details": {
+              "size": 2293094,
+              "image": {
+                "width": 3000,
+                "height": 2000
+              }
+            },
+            "fileName": "matt-palmer-254999.jpg",
+            "contentType": "image/jpeg"
+          }
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "4NzwDSDlGECGIiokKomsyI",
+        "type": "Asset",
+        "createdAt": "2019-05-06T13:06:28.382Z",
+        "updatedAt": "2019-05-06T13:06:33.458Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 2,
+        "publishedAt": "2019-05-06T13:06:33.458Z",
+        "firstPublishedAt": "2019-05-06T13:06:33.458Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 3,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "City"
+        },
+        "description": {
+          "en-US": "City pictured from the sky"
+        },
+        "file": {
+          "en-US": {
+            "url": "//images.ctfassets.net/x2j9oc2f28ow/4NzwDSDlGECGIiokKomsyI/e1ad3c13133f35d2134ad2285b926702/denys-nevozhai-100695.jpg",
+            "details": {
+              "size": 15736986,
+              "image": {
+                "width": 3992,
+                "height": 2992
+              }
+            },
+            "fileName": "denys-nevozhai-100695.jpg",
+            "contentType": "image/jpeg"
+          }
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "4shwYI3POEGkw0Eg6kcyaQ",
+        "type": "Asset",
+        "createdAt": "2019-05-06T13:06:28.393Z",
+        "updatedAt": "2019-05-06T13:06:33.381Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 2,
+        "publishedAt": "2019-05-06T13:06:33.381Z",
+        "firstPublishedAt": "2019-05-06T13:06:33.381Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 3,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Man in the fields"
+        },
+        "description": {
+          "en-US": "Tattooed man walking in a field"
+        },
+        "file": {
+          "en-US": {
+            "url": "//images.ctfassets.net/x2j9oc2f28ow/4shwYI3POEGkw0Eg6kcyaQ/fc7101c4cd83bd4baa6e1ff5ffd21d1b/felix-russell-saw-112140.jpg",
+            "details": {
+              "size": 4539181,
+              "image": {
+                "width": 2500,
+                "height": 1667
+              }
+            },
+            "fileName": "felix-russell-saw-112140.jpg",
+            "contentType": "image/jpeg"
+          }
+        }
+      }
+    }
+  ],
+  "locales": [
+    {
+      "name": "English (United States)",
+      "code": "en-US",
+      "fallbackCode": null,
+      "default": true,
+      "contentManagementApi": true,
+      "contentDeliveryApi": true,
+      "optional": false,
+      "sys": {
+        "type": "Locale",
+        "id": "5houKx9MbN34ShZCWtXr6u",
+        "version": 1,
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "environment": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Environment",
+            "id": "master"
+          }
+        },
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "createdAt": "2019-05-06T13:06:25Z",
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedAt": "2019-05-06T13:06:25Z"
+      }
+    }
+  ],
+  "webhooks": [],
+  "roles": []
+}

--- a/test/fixtures/simpleSchema.json
+++ b/test/fixtures/simpleSchema.json
@@ -1,0 +1,796 @@
+{
+  "contentTypes": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "person",
+        "type": "ContentType",
+        "createdAt": "2019-05-06T13:06:27.242Z",
+        "updatedAt": "2019-05-06T13:06:27.725Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 1,
+        "publishedAt": "2019-05-06T13:06:27.725Z",
+        "firstPublishedAt": "2019-05-06T13:06:27.725Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 2,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "displayField": "name",
+      "name": "Person",
+      "description": null,
+      "fields": [
+        {
+          "id": "name",
+          "name": "Name",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "title",
+          "name": "Title",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "company",
+          "name": "Company",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "shortBio",
+          "name": "Short Bio",
+          "type": "Text",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "email",
+          "name": "Email",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "phone",
+          "name": "Phone",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "facebook",
+          "name": "Facebook",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "twitter",
+          "name": "Twitter",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "github",
+          "name": "Github",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "image",
+          "name": "Image",
+          "type": "Link",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Asset"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "blog",
+        "type": "ContentType",
+        "createdAt": "2020-06-25T09:30:26.801Z",
+        "updatedAt": "2020-06-25T09:30:27.212Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 1,
+        "publishedAt": "2020-06-25T09:30:27.212Z",
+        "firstPublishedAt": "2020-06-25T09:30:27.212Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 2,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "displayField": null,
+      "name": "Blog",
+      "description": "",
+      "fields": [
+        {
+          "id": "body",
+          "name": "body",
+          "type": "RichText",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "nodes": {
+              }
+            },
+            {
+              "enabledNodeTypes": [
+                "heading-1",
+                "heading-2",
+                "heading-3",
+                "heading-4",
+                "heading-5",
+                "heading-6",
+                "ordered-list",
+                "unordered-list",
+                "hr",
+                "blockquote",
+                "embedded-asset-block",
+                "asset-hyperlink"
+              ],
+              "message": "Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, asset, and link to asset nodes are allowed"
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        }
+      ]
+    }
+  ],
+  "editorInterfaces": [
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "space": {
+          "sys": {
+            "id": "x2j9oc2f28ow",
+            "type": "Link",
+            "linkType": "Space"
+          }
+        },
+        "version": 1,
+        "createdAt": "2019-05-06T13:06:27.854Z",
+        "createdBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "updatedAt": "2019-05-06T13:06:27.854Z",
+        "updatedBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "id": "person",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "name",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "title",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "company",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "shortBio",
+          "widgetId": "markdown"
+        },
+        {
+          "fieldId": "email",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "phone",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "facebook",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "twitter",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "github",
+          "widgetId": "singleLine"
+        },
+        {
+          "fieldId": "image",
+          "widgetId": "assetLinkEditor"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "space": {
+          "sys": {
+            "id": "x2j9oc2f28ow",
+            "type": "Link",
+            "linkType": "Space"
+          }
+        },
+        "version": 2,
+        "createdAt": "2020-06-25T09:30:27.302Z",
+        "createdBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "updatedAt": "2020-06-25T09:30:28.023Z",
+        "updatedBy": {
+          "sys": {
+            "id": "4RIo3QLXzJZIsRleYS8gmL",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "id": "blog",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        }
+      },
+      "controls": [
+        {
+          "fieldId": "body",
+          "widgetId": "richTextEditor",
+          "widgetNamespace": "builtin"
+        }
+      ]
+    }
+  ],
+  "entries": [
+  ],
+  "assets": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "6Od9v3wzLOysiMum0Wkmme",
+        "type": "Asset",
+        "createdAt": "2019-05-06T13:06:28.375Z",
+        "updatedAt": "2019-05-06T13:06:33.353Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 2,
+        "publishedAt": "2019-05-06T13:06:33.353Z",
+        "firstPublishedAt": "2019-05-06T13:06:33.353Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 3,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Woman with black hat"
+        },
+        "description": {
+          "en-US": "Woman wearing a black hat"
+        },
+        "file": {
+          "en-US": {
+            "url": "//images.ctfassets.net/x2j9oc2f28ow/6Od9v3wzLOysiMum0Wkmme/683bf4b5de422ed9a29e66e0fc4604ca/cameron-kirby-88711.jpg",
+            "details": {
+              "size": 7316629,
+              "image": {
+                "width": 3000,
+                "height": 2000
+              }
+            },
+            "fileName": "cameron-kirby-88711.jpg",
+            "contentType": "image/jpeg"
+          }
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "7orLdboQQowIUs22KAW4U",
+        "type": "Asset",
+        "createdAt": "2019-05-06T13:06:28.379Z",
+        "updatedAt": "2019-05-06T13:06:33.352Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 2,
+        "publishedAt": "2019-05-06T13:06:33.352Z",
+        "firstPublishedAt": "2019-05-06T13:06:33.352Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 3,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Sparkler"
+        },
+        "description": {
+          "en-US": "John with Sparkler"
+        },
+        "file": {
+          "en-US": {
+            "url": "//images.ctfassets.net/x2j9oc2f28ow/7orLdboQQowIUs22KAW4U/7781b3d7ea651768d2a6eac6e65b2bcd/matt-palmer-254999.jpg",
+            "details": {
+              "size": 2293094,
+              "image": {
+                "width": 3000,
+                "height": 2000
+              }
+            },
+            "fileName": "matt-palmer-254999.jpg",
+            "contentType": "image/jpeg"
+          }
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "4NzwDSDlGECGIiokKomsyI",
+        "type": "Asset",
+        "createdAt": "2019-05-06T13:06:28.382Z",
+        "updatedAt": "2019-05-06T13:06:33.458Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 2,
+        "publishedAt": "2019-05-06T13:06:33.458Z",
+        "firstPublishedAt": "2019-05-06T13:06:33.458Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 3,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "City"
+        },
+        "description": {
+          "en-US": "City pictured from the sky"
+        },
+        "file": {
+          "en-US": {
+            "url": "//images.ctfassets.net/x2j9oc2f28ow/4NzwDSDlGECGIiokKomsyI/e1ad3c13133f35d2134ad2285b926702/denys-nevozhai-100695.jpg",
+            "details": {
+              "size": 15736986,
+              "image": {
+                "width": 3992,
+                "height": 2992
+              }
+            },
+            "fileName": "denys-nevozhai-100695.jpg",
+            "contentType": "image/jpeg"
+          }
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "4shwYI3POEGkw0Eg6kcyaQ",
+        "type": "Asset",
+        "createdAt": "2019-05-06T13:06:28.393Z",
+        "updatedAt": "2019-05-06T13:06:33.381Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 2,
+        "publishedAt": "2019-05-06T13:06:33.381Z",
+        "firstPublishedAt": "2019-05-06T13:06:33.381Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 3,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Man in the fields"
+        },
+        "description": {
+          "en-US": "Tattooed man walking in a field"
+        },
+        "file": {
+          "en-US": {
+            "url": "//images.ctfassets.net/x2j9oc2f28ow/4shwYI3POEGkw0Eg6kcyaQ/fc7101c4cd83bd4baa6e1ff5ffd21d1b/felix-russell-saw-112140.jpg",
+            "details": {
+              "size": 4539181,
+              "image": {
+                "width": 2500,
+                "height": 1667
+              }
+            },
+            "fileName": "felix-russell-saw-112140.jpg",
+            "contentType": "image/jpeg"
+          }
+        }
+      }
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "id": "7wWzFZClWaKvhTxh0pC9ps",
+        "type": "Asset",
+        "createdAt": "2020-06-24T16:36:15.564Z",
+        "updatedAt": "2020-06-24T16:37:23.290Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 5,
+        "publishedAt": "2020-06-24T16:37:23.290Z",
+        "firstPublishedAt": "2020-06-24T16:37:23.290Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 6,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Unpublished asset"
+        },
+        "description": {
+          "en-US": "This is not published!"
+        },
+        "file": {
+          "en-US": {
+            "url": "//images.ctfassets.net/x2j9oc2f28ow/7wWzFZClWaKvhTxh0pC9ps/fd643f5dd9f0e43e846d971824ae1a9c/1280px-Trollstigen_Norway_2004.jpg",
+            "details": {
+              "size": 549375,
+              "image": {
+                "width": 1280,
+                "height": 844
+              }
+            },
+            "fileName": "1280px-Trollstigen_Norway_2004.jpg",
+            "contentType": "image/jpeg"
+          }
+        }
+      }
+    }
+  ],
+  "locales": [
+    {
+      "name": "English (United States)",
+      "code": "en-US",
+      "fallbackCode": null,
+      "default": true,
+      "contentManagementApi": true,
+      "contentDeliveryApi": true,
+      "optional": false,
+      "sys": {
+        "type": "Locale",
+        "id": "5houKx9MbN34ShZCWtXr6u",
+        "version": 1,
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "x2j9oc2f28ow"
+          }
+        },
+        "environment": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Environment",
+            "id": "master"
+          }
+        },
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "createdAt": "2019-05-06T13:06:25Z",
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "4RIo3QLXzJZIsRleYS8gmL"
+          }
+        },
+        "updatedAt": "2019-05-06T13:06:25Z"
+      }
+    }
+  ],
+  "webhooks": [
+  ],
+  "roles": [
+  ]
+}

--- a/test/transformData.test.js
+++ b/test/transformData.test.js
@@ -1,0 +1,14 @@
+const assert = require("assert");
+const transformData = require("../src/transformData");
+const hr = require("./fixtures/hrexport.json");
+
+describe("transformData", () => {
+  describe("RichText", () => {
+    it("handles HR", () => {
+      const res = transformData(hr);
+      const doc = res[0];
+      assert(doc, "Didnt produce document");
+      expect(doc.body[1]._type).toBe("break");
+    });
+  });
+});

--- a/test/transformSchema.test.js
+++ b/test/transformSchema.test.js
@@ -1,0 +1,79 @@
+const transformSchema = require("../src/transformSchema");
+const assert = require("assert");
+
+const defaultOptions = {
+  keepMarkdown: true, // This is not connected to RichText
+};
+
+describe("transformSchema", () => {
+  describe("RichText", () => {
+    const fixture = require("./fixtures/richText.json");
+    it("includes an object for handling HR", () => {
+      const schema = transformSchema(fixture, defaultOptions);
+      assert(
+        schema.filter(
+          (typeDef) => typeDef.name === "break" && typeDef.type == "object"
+        ).length === 1,
+        "Did not export break type for dealing with HR"
+      );
+    });
+
+    it("uses portableText type for RichText fields", () => {
+      const schema = transformSchema(fixture, defaultOptions);
+      const doc = schema.find(
+        (typeDef) =>
+          typeDef.name === "fullRichText" && typeDef.type === "document"
+      );
+      assert(doc, "Could not find document");
+
+      const field = doc.fields.find((field) => field.name == "body");
+      assert(!!field, "Missing body field");
+      expect(field.type).toEqual("portableText");
+    });
+
+    it("Allows inline references to other documents and images", () => {
+      const fixture = require("./fixtures/simpleSchema.json");
+      const schema = transformSchema(fixture, defaultOptions);
+
+      const ptType = schema.find((typeDef) => typeDef.name === "portableText");
+
+      // Inline
+      const block = ptType.of.find((member) => member.type === "block");
+      assert(block, "Missing block type in portableText");
+      expect(block).toEqual(
+        expect.objectContaining({
+          of: expect.arrayContaining([
+            { type: "image" },
+            {
+              type: "reference",
+              name: "personRef",
+              to: [{ type: "person" }],
+            },
+            {
+              type: "reference",
+              name: "blogRef",
+              to: [{ type: "blog" }],
+            },
+          ]),
+        })
+      );
+    });
+
+    it("Allows block references to other documents and images", () => {
+      const fixture = require("./fixtures/simpleSchema.json");
+      const schema = transformSchema(fixture, defaultOptions);
+
+      const ptType = schema.find((typeDef) => typeDef.name === "portableText");
+
+      // Block
+      expect(ptType.of).toEqual(
+        expect.arrayContaining([
+          { type: "image" },
+          { type: "break" },
+          { type: "reference", name: "personRef", to: [{ type: "person" }] },
+          { type: "reference", name: "blogRef", to: [{ type: "blog" }] },
+        ])
+      );
+    });
+  });
+});

--- a/test/transformSchema.test.js
+++ b/test/transformSchema.test.js
@@ -1,79 +1,93 @@
-const transformSchema = require("../src/transformSchema");
-const assert = require("assert");
+const transformSchema = require('../src/transformSchema')
+const assert = require('assert')
 
 const defaultOptions = {
-  keepMarkdown: true, // This is not connected to RichText
-};
+    keepMarkdown: true, // This is not connected to RichText
+}
 
-describe("transformSchema", () => {
-  describe("RichText", () => {
-    const fixture = require("./fixtures/richText.json");
-    it("includes an object for handling HR", () => {
-      const schema = transformSchema(fixture, defaultOptions);
-      assert(
-        schema.filter(
-          (typeDef) => typeDef.name === "break" && typeDef.type == "object"
-        ).length === 1,
-        "Did not export break type for dealing with HR"
-      );
-    });
-
-    it("uses portableText type for RichText fields", () => {
-      const schema = transformSchema(fixture, defaultOptions);
-      const doc = schema.find(
-        (typeDef) =>
-          typeDef.name === "fullRichText" && typeDef.type === "document"
-      );
-      assert(doc, "Could not find document");
-
-      const field = doc.fields.find((field) => field.name == "body");
-      assert(!!field, "Missing body field");
-      expect(field.type).toEqual("portableText");
-    });
-
-    it("Allows inline references to other documents and images", () => {
-      const fixture = require("./fixtures/simpleSchema.json");
-      const schema = transformSchema(fixture, defaultOptions);
-
-      const ptType = schema.find((typeDef) => typeDef.name === "portableText");
-
-      // Inline
-      const block = ptType.of.find((member) => member.type === "block");
-      assert(block, "Missing block type in portableText");
-      expect(block).toEqual(
-        expect.objectContaining({
-          of: expect.arrayContaining([
-            { type: "image" },
-            {
-              type: "reference",
-              name: "personRef",
-              to: [{ type: "person" }],
-            },
-            {
-              type: "reference",
-              name: "blogRef",
-              to: [{ type: "blog" }],
-            },
-          ]),
+describe('transformSchema', () => {
+    describe('RichText', () => {
+        const fixture = require('./fixtures/richText.json')
+        it('includes an object for handling HR', () => {
+            const schema = transformSchema(fixture, defaultOptions)
+            assert(
+                schema.filter(
+                    typeDef =>
+                        typeDef.name === 'break' && typeDef.type == 'object'
+                ).length === 1,
+                'Did not export break type for dealing with HR'
+            )
         })
-      );
-    });
 
-    it("Allows block references to other documents and images", () => {
-      const fixture = require("./fixtures/simpleSchema.json");
-      const schema = transformSchema(fixture, defaultOptions);
+        it('uses portableText type for RichText fields', () => {
+            const schema = transformSchema(fixture, defaultOptions)
+            const doc = schema.find(
+                typeDef =>
+                    typeDef.name === 'fullRichText' &&
+                    typeDef.type === 'document'
+            )
+            assert(doc, 'Could not find document')
 
-      const ptType = schema.find((typeDef) => typeDef.name === "portableText");
+            const field = doc.fields.find(field => field.name == 'body')
+            assert(!!field, 'Missing body field')
+            expect(field.type).toEqual('portableText')
+        })
 
-      // Block
-      expect(ptType.of).toEqual(
-        expect.arrayContaining([
-          { type: "image" },
-          { type: "break" },
-          { type: "reference", name: "personRef", to: [{ type: "person" }] },
-          { type: "reference", name: "blogRef", to: [{ type: "blog" }] },
-        ])
-      );
-    });
-  });
-});
+        it('Allows inline references to other documents and images', () => {
+            const fixture = require('./fixtures/simpleSchema.json')
+            const schema = transformSchema(fixture, defaultOptions)
+
+            const ptType = schema.find(
+                typeDef => typeDef.name === 'portableText'
+            )
+
+            // Inline
+            const block = ptType.of.find(member => member.type === 'block')
+            assert(block, 'Missing block type in portableText')
+            expect(block).toEqual(
+                expect.objectContaining({
+                    of: expect.arrayContaining([
+                        { type: 'image' },
+                        {
+                            type: 'reference',
+                            name: 'personRef',
+                            to: [{ type: 'person' }],
+                        },
+                        {
+                            type: 'reference',
+                            name: 'blogRef',
+                            to: [{ type: 'blog' }],
+                        },
+                    ]),
+                })
+            )
+        })
+
+        it('Allows block references to other documents and images', () => {
+            const fixture = require('./fixtures/simpleSchema.json')
+            const schema = transformSchema(fixture, defaultOptions)
+
+            const ptType = schema.find(
+                typeDef => typeDef.name === 'portableText'
+            )
+
+            // Block
+            expect(ptType.of).toEqual(
+                expect.arrayContaining([
+                    { type: 'image' },
+                    { type: 'break' },
+                    {
+                        type: 'reference',
+                        name: 'personRef',
+                        to: [{ type: 'person' }],
+                    },
+                    {
+                        type: 'reference',
+                        name: 'blogRef',
+                        to: [{ type: 'blog' }],
+                    },
+                ])
+            )
+        })
+    })
+})


### PR DESCRIPTION
Implements handling of RichText by using `contentful-rich-text-to-portable-text` for the data transformation, and defining a `portableText` type allowing inlining and block embedding of images and all other document types, and a `break` object in order to handle Contentfuls `hr` node.

Before this can be released
- [ ] npm module `contentful-rich-text-to-portable-text` needs to be released