### PR TITLE
fix(schema): use mapped type if no widget id can be resolved

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -9,5 +9,8 @@
   ],
   "parserOptions": {
     "ecmaVersion": 2017
+  },
+  "rules": {
+    "max-depth": [5, "warn"]
   }
 }

--- a/src/transformSchema.js
+++ b/src/transformSchema.js
@@ -132,9 +132,8 @@ function shouldSkip(source, data, typeId) {
   const editor = data.editorInterfaces.find(
     (ed) => ed.sys.contentType.sys.id === typeId
   )
-  const widgetId = editor.controls.find(
-    (ctrl) => ctrl.fieldId === source.id
-  ).widgetId
+  const control = editor.controls.find((ctrl) => ctrl.fieldId === source.id)
+  const widgetId = control && control.widgetId
   return source.type === 'Object' && widgetId === 'objectEditor'
 }
 
@@ -142,9 +141,8 @@ function contentfulTypeToSanityType(source, data, typeId, options) {
   const editor = data.editorInterfaces.find(
     (ed) => ed.sys.contentType.sys.id === typeId
   )
-  const widgetId = editor.controls.find(
-    (ctrl) => ctrl.fieldId === source.id
-  ).widgetId
+  const control = editor.controls.find((ctrl) => ctrl.fieldId === source.id)
+  const widgetId = control && control.widgetId
   const defaultEditor = defaultEditors[source.type]
   const sanityEquivalent = directMap[source.type]
 
@@ -195,6 +193,10 @@ function contentfulTypeToSanityType(source, data, typeId, options) {
   if (source.type === 'RichText') {
     // this is a type we supply. See the portableTextType() function
     return {type: 'portableText'}
+  }
+
+  if (sanityEquivalent && typeof widgetId === 'undefined') {
+    return {type: sanityEquivalent}
   }
 
   throw new Error(

--- a/test/fixtures/simpleSchema.json
+++ b/test/fixtures/simpleSchema.json
@@ -52,6 +52,16 @@
       "description": null,
       "fields": [
         {
+          "id": "id",
+          "name": "ID",
+          "type": "Number",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
           "id": "name",
           "name": "Name",
           "type": "Symbol",
@@ -284,6 +294,9 @@
         }
       },
       "controls": [
+        {
+          "fieldId": "id"
+        },
         {
           "fieldId": "name",
           "widgetId": "singleLine"

--- a/test/transformData.test.js
+++ b/test/transformData.test.js
@@ -1,3 +1,4 @@
+/* eslint-env jest */
 const assert = require('assert')
 const transformData = require('../src/transformData')
 

--- a/test/transformSchema.test.js
+++ b/test/transformSchema.test.js
@@ -1,13 +1,36 @@
-const transformSchema = require('../src/transformSchema')
+/* eslint-env jest */
 const assert = require('assert')
+const transformSchema = require('../src/transformSchema')
 
 const defaultOptions = {
   keepMarkdown: true // This is not connected to RichText
 }
 
 describe('transformSchema', () => {
+  describe('defaults', () => {
+    const fixture = require('./fixtures/simpleSchema.json')
+
+    it('handles missing widget ids', () => {
+      const schema = transformSchema(fixture, defaultOptions)
+      const person = schema.find((typeDef) => typeDef.name === 'person')
+      expect(person).toBeTruthy()
+
+      const idField = person.fields.find((fieldDef) => fieldDef.name === 'id')
+      expect(idField).toBeTruthy()
+      expect(idField).toMatchInlineSnapshot(`
+        Object {
+          "name": "id",
+          "required": true,
+          "title": "ID",
+          "type": "number",
+        }
+      `)
+    })
+  })
+
   describe('RichText', () => {
     const fixture = require('./fixtures/richText.json')
+
     it('includes an object for handling HR', () => {
       const schema = transformSchema(fixture, defaultOptions)
       assert(


### PR DESCRIPTION
Apparently contentful sometimes returns a control without widget. In this case, if we've already found a matching sanity equivalent for the data type we should use it.

