### PR TITLE
fix: correct serialization of uri ruleSpec

### DIFF
--- a/src/helpers/sanity/serializeRuleSpecToCode.ts
+++ b/src/helpers/sanity/serializeRuleSpecToCode.ts
@@ -5,6 +5,7 @@ import omit from 'just-omit'
 export const serializeRuleSpecToCode = (ruleSpec: RuleSpec): string => {
   switch (ruleSpec.flag) {
     case 'uri':
+      return `uri(${stringify(ruleSpec.constraint.options)})`
     case 'presence':
       if (ruleSpec.constraint === 'optional') return ''
       return 'required()'

--- a/src/test/__snapshots__/contentfulToStudioSchema.test.ts.snap
+++ b/src/test/__snapshots__/contentfulToStudioSchema.test.ts.snap
@@ -14624,7 +14624,12 @@ export const layoutCopyType = defineType({
         Rule.regex(
           /^(ftp|http|https):\\\\/\\\\/(\\\\w+:{0,1}\\\\w*@)?(\\\\S+)(:[0-9]+)?(\\\\/|\\\\/([\\\\w#!:.?+=&%@!\\\\-\\\\/]))?$/,
           {invert: false},
-        ).required(),
+        ).uri({
+          allowCredentials: true,
+          allowRelative: true,
+          relativeOnly: false,
+          scheme: [/^http/, /^https/],
+        }),
     }),
     defineField({
       name: 'visualStyle',
@@ -15104,7 +15109,12 @@ export const layoutCopyType = {
         Rule.regex(
           /^(ftp|http|https):\\\\/\\\\/(\\\\w+:{0,1}\\\\w*@)?(\\\\S+)(:[0-9]+)?(\\\\/|\\\\/([\\\\w#!:.?+=&%@!\\\\-\\\\/]))?$/,
           {invert: false},
-        ).required(),
+        ).uri({
+          allowCredentials: true,
+          allowRelative: true,
+          relativeOnly: false,
+          scheme: [/^http/, /^https/],
+        }),
     },
     {
       name: 'visualStyle',
@@ -15585,7 +15595,12 @@ export const layoutCopyType = defineType({
         Rule.regex(
           /^(ftp|http|https):\\\\/\\\\/(\\\\w+:{0,1}\\\\w*@)?(\\\\S+)(:[0-9]+)?(\\\\/|\\\\/([\\\\w#!:.?+=&%@!\\\\-\\\\/]))?$/,
           {invert: false},
-        ).required(),
+        ).uri({
+          allowCredentials: true,
+          allowRelative: true,
+          relativeOnly: false,
+          scheme: [/^http/, /^https/],
+        }),
     }),
     defineField({
       name: 'visualStyle',
@@ -16009,7 +16024,12 @@ export const layoutCopyType = defineType({
         Rule.regex(
           /^(ftp|http|https):\\\\/\\\\/(\\\\w+:{0,1}\\\\w*@)?(\\\\S+)(:[0-9]+)?(\\\\/|\\\\/([\\\\w#!:.?+=&%@!\\\\-\\\\/]))?$/,
           {invert: false},
-        ).required(),
+        ).uri({
+          allowCredentials: true,
+          allowRelative: true,
+          relativeOnly: false,
+          scheme: [/^http/, /^https/],
+        }),
     }),
     defineField({
       name: 'visualStyle',

--- a/src/test/validations.test.ts
+++ b/src/test/validations.test.ts
@@ -66,4 +66,31 @@ describe('Validations', () => {
       'custom((value) => value === "foo" ? true : { message: "Value must be foo" })',
     )
   })
+
+  test('transforms uri validation to javascript according to Sanity Studio validations API', () => {
+    expect(
+      serializeRuleSpecToCode({
+        flag: 'uri',
+        constraint: {
+          options: {
+            scheme: [/^ftp/],
+            allowCredentials: true,
+            allowRelative: true,
+            relativeOnly: false,
+          },
+        },
+      }),
+    ).to.equal('uri({scheme:[/^ftp/],allowCredentials:true,allowRelative:true,relativeOnly:false})')
+
+    expect(
+      serializeRuleSpecToCode({
+        flag: 'uri',
+        constraint: {
+          options: {
+            scheme: ['http', 'https'], // This type seems to be wrong in @sanity/types. See https://www.sanity.io/docs/url-type
+          },
+        },
+      }),
+    ).to.equal(`uri({scheme:['http','https']})`)
+  })
 })

--- a/src/test/validations.test.ts
+++ b/src/test/validations.test.ts
@@ -87,6 +87,7 @@ describe('Validations', () => {
         flag: 'uri',
         constraint: {
           options: {
+            // @ts-expect-error wrong type
             scheme: ['http', 'https'], // This type seems to be wrong in @sanity/types. See https://www.sanity.io/docs/url-type
           },
         },


### PR DESCRIPTION
An error left a fall-through in the ruleSpec serialization switch, so `uri` ruleSpecs were incorectly added as `required`. This patch adds test cases and proper handling of this rulespec.