### PR TITLE
Implement drafts

### DIFF
--- a/src/actions/batchAction.ts
+++ b/src/actions/batchAction.ts
@@ -13,6 +13,7 @@ export async function batchAction({
   keepMarkdown,
   locale,
   managementToken,
+  accessToken,
   saveFile,
   schemaFile,
   spaceId,
@@ -23,6 +24,7 @@ export async function batchAction({
     exportDir,
     exportFile,
     managementToken,
+    accessToken,
     saveFile,
     spaceId,
   })

--- a/src/actions/datasetAction.ts
+++ b/src/actions/datasetAction.ts
@@ -26,20 +26,32 @@ export async function datasetAction({
     isAbsolutePath(exportFilePath),
     `exportFilePath must be an absolute path: ${exportFilePath}`,
   )
+  const publishedExportFilePath = path.join(
+    exportDir,
+    path.parse(exportFile).name + '.published.json',
+  )
   const datasetFilePath = path.join(exportDir, datasetFile)
   invariant(
     isAbsolutePath(datasetFilePath),
     `datasetFilePath must be an absolute path: ${datasetFilePath}`,
   )
 
-  const data: ContentfulExport = JSON.parse(await readFile(exportFilePath, 'utf8'))
-
-  const convertedDataset = await contentfulToDataset(data, {
-    intlMode,
-    weakRefs,
-    intlIdStructure,
-    keepMarkdown,
-    locale,
-  })
+  const draftData: ContentfulExport = JSON.parse(await readFile(exportFilePath, 'utf8'))
+  const publishedData: ContentfulExport = JSON.parse(
+    await readFile(publishedExportFilePath, 'utf8'),
+  )
+  const convertedDataset = await contentfulToDataset(
+    {
+      drafts: draftData,
+      published: publishedData,
+    },
+    {
+      intlMode,
+      weakRefs,
+      intlIdStructure,
+      keepMarkdown,
+      locale,
+    },
+  )
   await writeFile(datasetFilePath, convertedDataset)
 }

--- a/src/actions/exportAction.ts
+++ b/src/actions/exportAction.ts
@@ -28,6 +28,7 @@ export async function exportAction({
     environmentId,
     skipContentModel: false,
     skipEditorInterfaces: false,
+    includeDrafts: true,
     // If saveFile is false, then we're not exporting data, we're exporting what we need to generate a schema
     skipWebhooks: true,
     skipRoles: true,

--- a/src/actions/exportAction.ts
+++ b/src/actions/exportAction.ts
@@ -1,6 +1,7 @@
 import isAbsolutePath from '@stdlib/assert-is-absolute-path'
 import contentfulExport from 'contentful-export'
 import {mkdirp} from 'mkdirp'
+import path from 'path'
 import invariant from 'tiny-invariant'
 
 import type {ExportActionArgs} from '../parsers/exportActionArgs'
@@ -9,6 +10,7 @@ import {absolutify} from '../utils/absolutify'
 export async function exportAction({
   exportDir: _exportDir,
   spaceId,
+  accessToken,
   managementToken,
   environmentId,
   saveFile,
@@ -22,7 +24,7 @@ export async function exportAction({
   // eslint-disable-next-line no-warning-comments
   // @TODO use https://listr2.kilic.dev/ to add interactive prompts if spaceId or managementToken are missing
 
-  await contentfulExport({
+  const options = {
     spaceId,
     managementToken,
     environmentId,
@@ -33,7 +35,7 @@ export async function exportAction({
     skipWebhooks: true,
     skipRoles: true,
     downloadAssets: false,
-    maxAllowedLimit: 50,
+    maxAllowedLimit: 250,
     contentFile: exportFile,
     // errorLogFile: `${exportFile}.error.log`,
     // Options related to exports to the filesystem, not relevant if used in a Remix loader and a pass-through export just
@@ -43,5 +45,21 @@ export async function exportAction({
     exportDir,
     skipContent: false,
     saveFile,
+  }
+
+  // Export the content model and editor interfaces, drafts. Published versions
+  // will not be available in the export since if they are changed only the
+  // current draft edits will be included.
+  await contentfulExport(options)
+
+  // We solve that by running an additional export of only published content
+  // with a delivery token
+  await contentfulExport({
+    ...options,
+    //skipContentModel: true,
+    //skipEditorInterfaces: true,
+    includeDrafts: false,
+    deliveryToken: accessToken,
+    contentFile: path.parse(exportFile).name + '.published.json',
   })
 }

--- a/src/cli/command.test.ts
+++ b/src/cli/command.test.ts
@@ -32,6 +32,7 @@ const mockData = {
   outdir: './export',
   spaceId: ['--space-id', '123'] as const,
   mgmtToken: ['--management-token', 'abc'] as const,
+  accessToken: ['--access-token', 'def'] as const,
 }
 
 describe('contentful-to-sanity [command] <outdir>', () => {
@@ -44,16 +45,23 @@ describe('contentful-to-sanity [command] <outdir>', () => {
   describe('export [options] <outdir>', () => {
     test('<outdir>', () => {
       expect(() =>
-        fab(['export', ...mockData.spaceId, ...mockData.mgmtToken]),
+        fab(['export', ...mockData.spaceId, ...mockData.mgmtToken, ...mockData.accessToken]),
       ).toThrowErrorMatchingInlineSnapshot('"error: missing required argument \'outdir\'"')
       expect(defaultActions.exportAction).not.toHaveBeenCalled()
 
-      fab(['export', ...mockData.spaceId, ...mockData.mgmtToken, mockData.outdir])
+      fab([
+        'export',
+        ...mockData.spaceId,
+        ...mockData.mgmtToken,
+        ...mockData.accessToken,
+        mockData.outdir,
+      ])
 
       expect(defaultActions.exportAction).toHaveBeenCalled()
       expect(defaultActions.exportAction.mock.calls[0]).toMatchInlineSnapshot(`
         [
           {
+            "accessToken": "def",
             "environmentId": "master",
             "exportDir": "./export",
             "exportFile": "contentful.json",
@@ -66,17 +74,24 @@ describe('contentful-to-sanity [command] <outdir>', () => {
     })
     test('--space-id', () => {
       expect(() =>
-        fab(['export', ...mockData.mgmtToken, mockData.outdir]),
+        fab(['export', ...mockData.mgmtToken, ...mockData.accessToken, mockData.outdir]),
       ).toThrowErrorMatchingInlineSnapshot(
         '"error: required option \'-s, --space-id <space-id>\' not specified"',
       )
       expect(defaultActions.exportAction).not.toHaveBeenCalled()
 
-      fab(['export', ...mockData.spaceId, ...mockData.mgmtToken, mockData.outdir])
+      fab([
+        'export',
+        ...mockData.spaceId,
+        ...mockData.mgmtToken,
+        ...mockData.accessToken,
+        mockData.outdir,
+      ])
       expect(defaultActions.exportAction).toHaveBeenCalled()
       expect(defaultActions.exportAction.mock.calls[0]).toMatchInlineSnapshot(`
         [
           {
+            "accessToken": "def",
             "environmentId": "master",
             "exportDir": "./export",
             "exportFile": "contentful.json",
@@ -89,17 +104,24 @@ describe('contentful-to-sanity [command] <outdir>', () => {
     })
     test('--management-token', () => {
       expect(() =>
-        fab(['export', ...mockData.spaceId, mockData.outdir]),
+        fab(['export', ...mockData.spaceId, ...mockData.accessToken, mockData.outdir]),
       ).toThrowErrorMatchingInlineSnapshot(
         '"error: required option \'-t, --management-token <management-token>\' not specified"',
       )
       expect(defaultActions.exportAction).not.toHaveBeenCalled()
 
-      fab(['export', ...mockData.spaceId, ...mockData.mgmtToken, mockData.outdir])
+      fab([
+        'export',
+        ...mockData.spaceId,
+        ...mockData.mgmtToken,
+        ...mockData.accessToken,
+        mockData.outdir,
+      ])
       expect(defaultActions.exportAction).toHaveBeenCalled()
       expect(defaultActions.exportAction.mock.calls[0]).toMatchInlineSnapshot(`
         [
           {
+            "accessToken": "def",
             "environmentId": "master",
             "exportDir": "./export",
             "exportFile": "contentful.json",
@@ -165,16 +187,23 @@ describe('contentful-to-sanity [command] <outdir>', () => {
   describe('batch [options] <outdir>', () => {
     test('<outdir>', () => {
       expect(() =>
-        fab(['batch', ...mockData.spaceId, ...mockData.mgmtToken]),
+        fab(['batch', ...mockData.spaceId, ...mockData.mgmtToken, ...mockData.accessToken]),
       ).toThrowErrorMatchingInlineSnapshot('"error: missing required argument \'outdir\'"')
       expect(defaultActions.batchAction).not.toHaveBeenCalled()
 
-      fab(['batch', ...mockData.spaceId, ...mockData.mgmtToken, mockData.outdir])
+      fab([
+        'batch',
+        ...mockData.spaceId,
+        ...mockData.mgmtToken,
+        ...mockData.accessToken,
+        mockData.outdir,
+      ])
 
       expect(defaultActions.batchAction).toHaveBeenCalled()
       expect(defaultActions.batchAction.mock.calls[0]).toMatchInlineSnapshot(`
         [
           {
+            "accessToken": "def",
             "datasetFile": "dataset.ndjson",
             "environmentId": "master",
             "exportDir": "./export",
@@ -193,17 +222,24 @@ describe('contentful-to-sanity [command] <outdir>', () => {
     })
     test('--space-id', () => {
       expect(() =>
-        fab(['batch', ...mockData.mgmtToken, mockData.outdir]),
+        fab(['batch', ...mockData.mgmtToken, ...mockData.accessToken, mockData.outdir]),
       ).toThrowErrorMatchingInlineSnapshot(
         '"error: required option \'-s, --space-id <space-id>\' not specified"',
       )
       expect(defaultActions.batchAction).not.toHaveBeenCalled()
 
-      fab(['batch', ...mockData.spaceId, ...mockData.mgmtToken, mockData.outdir])
+      fab([
+        'batch',
+        ...mockData.spaceId,
+        ...mockData.mgmtToken,
+        ...mockData.accessToken,
+        mockData.outdir,
+      ])
       expect(defaultActions.batchAction).toHaveBeenCalled()
       expect(defaultActions.batchAction.mock.calls[0]).toMatchInlineSnapshot(`
         [
           {
+            "accessToken": "def",
             "datasetFile": "dataset.ndjson",
             "environmentId": "master",
             "exportDir": "./export",
@@ -222,17 +258,67 @@ describe('contentful-to-sanity [command] <outdir>', () => {
     })
     test('--management-token', () => {
       expect(() =>
-        fab(['batch', ...mockData.spaceId, mockData.outdir]),
+        fab(['batch', ...mockData.spaceId, ...mockData.accessToken, mockData.outdir]),
       ).toThrowErrorMatchingInlineSnapshot(
         '"error: required option \'-t, --management-token <management-token>\' not specified"',
       )
       expect(defaultActions.batchAction).not.toHaveBeenCalled()
 
-      fab(['batch', ...mockData.spaceId, ...mockData.mgmtToken, mockData.outdir])
+      expect(() =>
+        fab(['batch', ...mockData.spaceId, ...mockData.mgmtToken, mockData.outdir]),
+      ).toThrowErrorMatchingInlineSnapshot(
+        '"error: required option \'-a, --access-token <access-token>\' not specified"',
+      )
+      expect(defaultActions.batchAction).not.toHaveBeenCalled()
+
+      fab([
+        'batch',
+        ...mockData.spaceId,
+        ...mockData.mgmtToken,
+        ...mockData.accessToken,
+        mockData.outdir,
+      ])
       expect(defaultActions.batchAction).toHaveBeenCalled()
       expect(defaultActions.batchAction.mock.calls[0]).toMatchInlineSnapshot(`
         [
           {
+            "accessToken": "def",
+            "datasetFile": "dataset.ndjson",
+            "environmentId": "master",
+            "exportDir": "./export",
+            "exportFile": "contentful.json",
+            "intl": "single",
+            "intlIdStructure": "delimiter",
+            "keepMarkdown": false,
+            "managementToken": "abc",
+            "saveFile": true,
+            "schemaFile": "schema.ts",
+            "spaceId": "123",
+            "weakRefs": false,
+          },
+        ]
+      `)
+    })
+    test('--access-token', () => {
+      expect(() =>
+        fab(['batch', ...mockData.spaceId, ...mockData.mgmtToken, mockData.outdir]),
+      ).toThrowErrorMatchingInlineSnapshot(
+        '"error: required option \'-a, --access-token <access-token>\' not specified"',
+      )
+      expect(defaultActions.batchAction).not.toHaveBeenCalled()
+
+      fab([
+        'batch',
+        ...mockData.spaceId,
+        ...mockData.mgmtToken,
+        ...mockData.accessToken,
+        mockData.outdir,
+      ])
+      expect(defaultActions.batchAction).toHaveBeenCalled()
+      expect(defaultActions.batchAction.mock.calls[0]).toMatchInlineSnapshot(`
+        [
+          {
+            "accessToken": "def",
             "datasetFile": "dataset.ndjson",
             "environmentId": "master",
             "exportDir": "./export",
@@ -286,6 +372,7 @@ describe('contentful-to-sanity [command] <outdir>', () => {
           Options:
             -s, --space-id <space-id>                  The Contentful space ID
             -t, --management-token <management-token>  Contentful Management API token
+            -a, --access-token <access-token>          Contentful Content Delivery API access token
             -e, --environment-id [environment-id[      Contentful environment (default: \\"master\\")
             --export-file [name]                       The filename for the exported JSON document that holds your Contentful data. (default: \\"contentful.json\\")
             -h, --help                                 display help for command
@@ -355,6 +442,7 @@ describe('contentful-to-sanity [command] <outdir>', () => {
           Options:
             -s, --space-id <space-id>                  The Contentful space ID
             -t, --management-token <management-token>  Contentful Management API token
+            -a, --access-token <access-token>          Contentful Content Delivery API access token
             -e, --environment-id [environment-id[      Contentful environment (default: \\"master\\")
             --export-file [name]                       The filename for the exported JSON document that holds your Contentful data. (default: \\"contentful.json\\")
             --schema-file [name]                       The filename for the generated Sanity Studio schema definitions file. Use \`.js\` file endings to strip TypeScript syntax. (default: \\"schema.ts\\")
@@ -392,11 +480,28 @@ describe('contentful-to-sanity [command] <outdir>', () => {
         sequence.push('batch:end')
       })
 
-      await fabAsync([...mockData.spaceId, ...mockData.mgmtToken, './export'])
-      await fabAsync(['export', ...mockData.spaceId, ...mockData.mgmtToken, './export'])
+      await fabAsync([
+        ...mockData.spaceId,
+        ...mockData.mgmtToken,
+        ...mockData.accessToken,
+        './export',
+      ])
+      await fabAsync([
+        'export',
+        ...mockData.spaceId,
+        ...mockData.mgmtToken,
+        ...mockData.accessToken,
+        './export',
+      ])
       await fabAsync(['schema', './export'])
       await fabAsync(['dataset', './export'])
-      await fabAsync(['batch', ...mockData.spaceId, ...mockData.mgmtToken, './export'])
+      await fabAsync([
+        'batch',
+        ...mockData.spaceId,
+        ...mockData.mgmtToken,
+        ...mockData.accessToken,
+        './export',
+      ])
       expect(sequence, 'actions are awaited in order').toEqual([
         'batch:start',
         'batch:end',

--- a/src/cli/command.ts
+++ b/src/cli/command.ts
@@ -35,6 +35,10 @@ const managementTokenOption = [
   '-t, --management-token <management-token>',
   'Contentful Management API token',
 ] as const
+const accessTokenOption = [
+  '-a, --access-token <access-token>',
+  'Contentful Content Delivery API access token',
+] as const
 const intlOption = new Option(
   '--intl [mode]',
   'Define the intl behavior. This is disabled by default and only one locale will be considered.',
@@ -107,6 +111,7 @@ export function makeProgram(opts: ProgramOptions = {}): Command {
     .argument(...outdirArgument)
     .requiredOption(...spaceIdOption)
     .requiredOption(...managementTokenOption)
+    .requiredOption(...accessTokenOption)
     .option(...environmentIdOption)
     .option(...exportFileOption)
     .action((exportDir, options) => {
@@ -169,6 +174,7 @@ export function makeProgram(opts: ProgramOptions = {}): Command {
     .argument(...outdirArgument)
     .requiredOption(...spaceIdOption)
     .requiredOption(...managementTokenOption)
+    .requiredOption(...accessTokenOption)
     .option(...environmentIdOption)
     .option(...exportFileOption)
     .option(...schemaFileOption)

--- a/src/helpers/contentfulToDataset.ts
+++ b/src/helpers/contentfulToDataset.ts
@@ -2,13 +2,17 @@ import {SanityDocument} from '@sanity/client'
 import compact from 'just-compact'
 import invariant from 'tiny-invariant'
 
-import {ContentfulExport} from '../types'
+import {type ContentfulExport} from '../types'
+import {isPublished} from '../utils/contentfulEntry'
 import {contentfulEntryToSanityObject} from '../utils/contentfulEntryToSanityObject'
 import {ContentfulNoDefaultLocaleError} from './errors/ContentfulNoDefaultLocaleError'
 import {ContentfulNoLocalesError} from './errors/ContentfulNoLocalesError'
 
 export async function contentfulToDataset(
-  data: ContentfulExport,
+  exports: {
+    drafts: ContentfulExport
+    published?: ContentfulExport
+  },
   opts: {
     intlMode: 'single' | 'multiple'
     weakRefs: boolean
@@ -17,45 +21,61 @@ export async function contentfulToDataset(
     locale: string | undefined
   },
 ): Promise<string> {
-  const useMultiLocale = opts.intlMode === 'multiple'
-  const defaultLocale = data.locales?.find((locale) => Boolean(locale.default))
-  if (!defaultLocale) {
-    throw new ContentfulNoDefaultLocaleError()
-  }
-  const localesToImport = (
-    useMultiLocale
-      ? (data.locales ?? []).map(({code}) => code)
-      : opts.locale
-      ? [opts.locale]
-      : compact([defaultLocale?.code])
-  ).filter((code) => data?.locales?.some((locale) => locale.code === code))
-
-  if (!defaultLocale) {
-    throw new ContentfulNoDefaultLocaleError()
-  }
-
-  if (localesToImport.length === 0) {
-    throw new ContentfulNoLocalesError()
-  }
-
-  invariant(data.entries, 'Expected data.entries to be defined')
-  invariant(data.entries.length > 0, 'Expected data.entries to be defined')
-
-  const importableEntries: Set<SanityDocument> = new Set()
-  for (const entry of data.entries) {
-    for (const locale of localesToImport) {
-      importableEntries.add(
-        contentfulEntryToSanityObject(entry, locale, data, {
-          useMultiLocale,
-          idStructure: opts.intlIdStructure,
-          defaultLocale: defaultLocale.code,
-          supportedLocales: localesToImport,
-          keepMarkdown: opts.keepMarkdown,
-          weakRefs: opts.weakRefs,
-        }),
-      )
+  const parseExport = (data: ContentfulExport, isContentDeliveryAPIExport = false) => {
+    const useMultiLocale = opts.intlMode === 'multiple'
+    const defaultLocale = data.locales?.find((locale) => Boolean(locale.default))
+    if (!defaultLocale) {
+      throw new ContentfulNoDefaultLocaleError()
     }
+    const localesToImport = (
+      useMultiLocale
+        ? (data.locales ?? []).map(({code}) => code)
+        : opts.locale
+        ? [opts.locale]
+        : compact([defaultLocale?.code])
+    ).filter((code) => data?.locales?.some((locale) => locale.code === code))
+
+    if (!defaultLocale) {
+      throw new ContentfulNoDefaultLocaleError()
+    }
+
+    if (localesToImport.length === 0) {
+      throw new ContentfulNoLocalesError()
+    }
+
+    invariant(data.entries, 'Expected data.entries to be defined')
+    invariant(data.entries.length > 0, 'Expected data.entries to be defined')
+
+    const importableEntries: Set<SanityDocument> = new Set()
+    for (const entry of data.entries) {
+      for (const locale of localesToImport) {
+        // We only want to import published entries if we're importing from the Content Delivery API
+        if (!isContentDeliveryAPIExport && isPublished(entry)) continue
+        const id = isContentDeliveryAPIExport
+          ? entry.sys.id
+          : isPublished(entry)
+          ? entry.sys.id
+          : `drafts.${entry.sys.id}`
+        importableEntries.add(
+          contentfulEntryToSanityObject(id, entry, locale, data, {
+            useMultiLocale,
+            idStructure: opts.intlIdStructure,
+            defaultLocale: defaultLocale.code,
+            supportedLocales: localesToImport,
+            keepMarkdown: opts.keepMarkdown,
+            weakRefs: opts.weakRefs,
+          }),
+        )
+      }
+    }
+
+    return [...importableEntries].map((entry) => JSON.stringify(entry)).join('\n')
   }
 
-  return [...importableEntries].map((entry) => JSON.stringify(entry)).join('\n')
+  return [
+    exports.drafts ? parseExport(exports.drafts, false) : '',
+    exports.published ? parseExport(exports.published, true) : '',
+  ]
+    .filter((line) => line.length)
+    .join('\n')
 }

--- a/src/helpers/contentfulToDataset.ts
+++ b/src/helpers/contentfulToDataset.ts
@@ -3,7 +3,7 @@ import compact from 'just-compact'
 import invariant from 'tiny-invariant'
 
 import {type ContentfulExport} from '../types'
-import {isPublished} from '../utils/contentfulEntry'
+import {isArchived, isChanged, isDraft} from '../utils/contentfulEntry'
 import {contentfulEntryToSanityObject} from '../utils/contentfulEntryToSanityObject'
 import {ContentfulNoDefaultLocaleError} from './errors/ContentfulNoDefaultLocaleError'
 import {ContentfulNoLocalesError} from './errors/ContentfulNoLocalesError'
@@ -21,41 +21,38 @@ export async function contentfulToDataset(
     locale: string | undefined
   },
 ): Promise<string> {
-  const parseExport = (data: ContentfulExport, isContentDeliveryAPIExport = false) => {
-    const useMultiLocale = opts.intlMode === 'multiple'
-    const defaultLocale = data.locales?.find((locale) => Boolean(locale.default))
-    if (!defaultLocale) {
-      throw new ContentfulNoDefaultLocaleError()
-    }
-    const localesToImport = (
-      useMultiLocale
-        ? (data.locales ?? []).map(({code}) => code)
-        : opts.locale
-        ? [opts.locale]
-        : compact([defaultLocale?.code])
-    ).filter((code) => data?.locales?.some((locale) => locale.code === code))
+  const data = exports.drafts // The metadata is in the draft export
+  const useMultiLocale = opts.intlMode === 'multiple'
+  const defaultLocale = data.locales?.find((locale) => Boolean(locale.default))
+  if (!defaultLocale) {
+    throw new ContentfulNoDefaultLocaleError()
+  }
+  const localesToImport = (
+    useMultiLocale
+      ? (data.locales ?? []).map(({code}) => code)
+      : opts.locale
+      ? [opts.locale]
+      : compact([defaultLocale?.code])
+  ).filter((code) => data?.locales?.some((locale) => locale.code === code))
 
-    if (!defaultLocale) {
-      throw new ContentfulNoDefaultLocaleError()
-    }
+  if (!defaultLocale) {
+    throw new ContentfulNoDefaultLocaleError()
+  }
 
-    if (localesToImport.length === 0) {
-      throw new ContentfulNoLocalesError()
-    }
+  if (localesToImport.length === 0) {
+    throw new ContentfulNoLocalesError()
+  }
 
-    invariant(data.entries, 'Expected data.entries to be defined')
-    invariant(data.entries.length > 0, 'Expected data.entries to be defined')
+  invariant(exports.drafts.entries, 'Expected data.entries to be defined')
+  invariant(exports.drafts.entries.length > 0, 'Expected data.entries to be defined')
 
-    const importableEntries: Set<SanityDocument> = new Set()
-    for (const entry of data.entries) {
-      for (const locale of localesToImport) {
-        // We only want to import published entries if we're importing from the Content Delivery API
-        if (!isContentDeliveryAPIExport && isPublished(entry)) continue
-        const id = isContentDeliveryAPIExport
-          ? entry.sys.id
-          : isPublished(entry)
-          ? entry.sys.id
-          : `drafts.${entry.sys.id}`
+  const importableEntries: Set<SanityDocument> = new Set()
+
+  for (const entry of exports.drafts.entries) {
+    for (const locale of localesToImport) {
+      // We only want to import published entries if we're importing from the Content Delivery API (aka exports.published)
+      if (isChanged(entry) || isDraft(entry) || isArchived(entry)) {
+        const id = isArchived(entry) ? entry.sys.id : `drafts.${entry.sys.id}`
         importableEntries.add(
           contentfulEntryToSanityObject(id, entry, locale, data, {
             useMultiLocale,
@@ -68,14 +65,23 @@ export async function contentfulToDataset(
         )
       }
     }
-
-    return [...importableEntries].map((entry) => JSON.stringify(entry)).join('\n')
   }
 
-  return [
-    exports.drafts ? parseExport(exports.drafts, false) : '',
-    exports.published ? parseExport(exports.published, true) : '',
-  ]
-    .filter((line) => line.length)
-    .join('\n')
+  for (const entry of exports.published?.entries ?? []) {
+    for (const locale of localesToImport) {
+      const id = entry.sys.id
+      importableEntries.add(
+        contentfulEntryToSanityObject(id, entry, locale, data, {
+          useMultiLocale,
+          idStructure: opts.intlIdStructure,
+          defaultLocale: defaultLocale.code,
+          supportedLocales: localesToImport,
+          keepMarkdown: opts.keepMarkdown,
+          weakRefs: opts.weakRefs,
+        }),
+      )
+    }
+  }
+
+  return [...importableEntries].map((entry) => JSON.stringify(entry)).join('\n')
 }

--- a/src/parsers/exportActionArgs.ts
+++ b/src/parsers/exportActionArgs.ts
@@ -6,6 +6,7 @@ export const exportActionArgs = z.object({
   exportDir: z.string().refine(isRelativePath),
   spaceId: z.string(),
   managementToken: z.string(),
+  accessToken: z.string(),
   environmentId: z.string(),
   saveFile: z.boolean(),
   exportFile: z.string().endsWith('.json').refine(isValidFilename),

--- a/src/test/__snapshots__/contentfulToDataset.test.ts.snap
+++ b/src/test/__snapshots__/contentfulToDataset.test.ts.snap
@@ -61631,7 +61631,7 @@ exports[`contentfulToDataset > the-example-app.json 1`] = `
   },
   {
     "_createdAt": "2017-11-08T16:06:59.430Z",
-    "_id": "drafts.4ZQtjYftNKaoKWuksM0sS0",
+    "_id": "4ZQtjYftNKaoKWuksM0sS0",
     "_rev": "4ZQtjYftNKaoKWuksM0sS0",
     "_type": "lessonCopy",
     "_updatedAt": "2018-02-01T13:53:26.380Z",
@@ -62296,7 +62296,7 @@ exports[`contentfulToDataset > the-example-app.json 1`] = `
   },
   {
     "_createdAt": "2017-12-12T14:02:49.950Z",
-    "_id": "drafts.77NL8rGPks6SauGuoG8ui",
+    "_id": "77NL8rGPks6SauGuoG8ui",
     "_rev": "77NL8rGPks6SauGuoG8ui",
     "_type": "layoutHeroImage",
     "_updatedAt": "2017-12-14T17:44:39.996Z",
@@ -62794,7 +62794,7 @@ exports[`contentfulToDataset > the-example-app.json 1`] = `
   },
   {
     "_createdAt": "2017-11-08T16:06:56.098Z",
-    "_id": "drafts.2uNOpLMJioKeoMq8W44uYc",
+    "_id": "2uNOpLMJioKeoMq8W44uYc",
     "_rev": "2uNOpLMJioKeoMq8W44uYc",
     "_type": "layout",
     "_updatedAt": "2018-01-24T11:37:16.429Z",
@@ -66204,12 +66204,12 @@ exports[`contentfulToDataset > the-example-app.json 2`] = `
     "__i18n_refs": [
       {
         "_key": "bb463b8b",
-        "_ref": "drafts.4ZQtjYftNKaoKWuksM0sS0__i18n_de-DE",
+        "_ref": "4ZQtjYftNKaoKWuksM0sS0__i18n_de-DE",
         "_type": "reference",
       },
     ],
     "_createdAt": "2017-11-08T16:06:59.430Z",
-    "_id": "drafts.4ZQtjYftNKaoKWuksM0sS0",
+    "_id": "4ZQtjYftNKaoKWuksM0sS0",
     "_rev": "4ZQtjYftNKaoKWuksM0sS0",
     "_type": "lessonCopy",
     "_updatedAt": "2018-02-01T13:53:26.380Z",
@@ -66303,12 +66303,12 @@ exports[`contentfulToDataset > the-example-app.json 2`] = `
   },
   {
     "__i18n_base": {
-      "_ref": "drafts.4ZQtjYftNKaoKWuksM0sS0",
+      "_ref": "4ZQtjYftNKaoKWuksM0sS0",
       "_type": "reference",
     },
     "__i18n_lang": "de-DE",
     "_createdAt": "2017-11-08T16:06:59.430Z",
-    "_id": "drafts.4ZQtjYftNKaoKWuksM0sS0",
+    "_id": "4ZQtjYftNKaoKWuksM0sS0",
     "_rev": "4ZQtjYftNKaoKWuksM0sS0",
     "_type": "lessonCopy",
     "_updatedAt": "2018-02-01T13:53:26.380Z",
@@ -67376,12 +67376,12 @@ exports[`contentfulToDataset > the-example-app.json 2`] = `
     "__i18n_refs": [
       {
         "_key": "bb463b8b",
-        "_ref": "drafts.77NL8rGPks6SauGuoG8ui__i18n_de-DE",
+        "_ref": "77NL8rGPks6SauGuoG8ui__i18n_de-DE",
         "_type": "reference",
       },
     ],
     "_createdAt": "2017-12-12T14:02:49.950Z",
-    "_id": "drafts.77NL8rGPks6SauGuoG8ui",
+    "_id": "77NL8rGPks6SauGuoG8ui",
     "_rev": "77NL8rGPks6SauGuoG8ui",
     "_type": "layoutHeroImage",
     "_updatedAt": "2017-12-14T17:44:39.996Z",
@@ -67394,12 +67394,12 @@ exports[`contentfulToDataset > the-example-app.json 2`] = `
   },
   {
     "__i18n_base": {
-      "_ref": "drafts.77NL8rGPks6SauGuoG8ui",
+      "_ref": "77NL8rGPks6SauGuoG8ui",
       "_type": "reference",
     },
     "__i18n_lang": "de-DE",
     "_createdAt": "2017-12-12T14:02:49.950Z",
-    "_id": "drafts.77NL8rGPks6SauGuoG8ui",
+    "_id": "77NL8rGPks6SauGuoG8ui",
     "_rev": "77NL8rGPks6SauGuoG8ui",
     "_type": "layoutHeroImage",
     "_updatedAt": "2017-12-14T17:44:39.996Z",
@@ -68308,12 +68308,12 @@ exports[`contentfulToDataset > the-example-app.json 2`] = `
     "__i18n_refs": [
       {
         "_key": "bb463b8b",
-        "_ref": "drafts.2uNOpLMJioKeoMq8W44uYc__i18n_de-DE",
+        "_ref": "2uNOpLMJioKeoMq8W44uYc__i18n_de-DE",
         "_type": "reference",
       },
     ],
     "_createdAt": "2017-11-08T16:06:56.098Z",
-    "_id": "drafts.2uNOpLMJioKeoMq8W44uYc",
+    "_id": "2uNOpLMJioKeoMq8W44uYc",
     "_rev": "2uNOpLMJioKeoMq8W44uYc",
     "_type": "layout",
     "_updatedAt": "2018-01-24T11:37:16.429Z",
@@ -68336,12 +68336,12 @@ exports[`contentfulToDataset > the-example-app.json 2`] = `
   },
   {
     "__i18n_base": {
-      "_ref": "drafts.2uNOpLMJioKeoMq8W44uYc",
+      "_ref": "2uNOpLMJioKeoMq8W44uYc",
       "_type": "reference",
     },
     "__i18n_lang": "de-DE",
     "_createdAt": "2017-11-08T16:06:56.098Z",
-    "_id": "drafts.2uNOpLMJioKeoMq8W44uYc",
+    "_id": "2uNOpLMJioKeoMq8W44uYc",
     "_rev": "2uNOpLMJioKeoMq8W44uYc",
     "_type": "layout",
     "_updatedAt": "2018-01-24T11:37:16.429Z",
@@ -70232,7 +70232,7 @@ exports[`contentfulToDataset > the-example-app.json 3`] = `
   },
   {
     "_createdAt": "2017-11-08T16:06:59.430Z",
-    "_id": "drafts.4ZQtjYftNKaoKWuksM0sS0",
+    "_id": "4ZQtjYftNKaoKWuksM0sS0",
     "_rev": "4ZQtjYftNKaoKWuksM0sS0",
     "_type": "lessonCopy",
     "_updatedAt": "2018-02-01T13:53:26.380Z",
@@ -70897,7 +70897,7 @@ exports[`contentfulToDataset > the-example-app.json 3`] = `
   },
   {
     "_createdAt": "2017-12-12T14:02:49.950Z",
-    "_id": "drafts.77NL8rGPks6SauGuoG8ui",
+    "_id": "77NL8rGPks6SauGuoG8ui",
     "_rev": "77NL8rGPks6SauGuoG8ui",
     "_type": "layoutHeroImage",
     "_updatedAt": "2017-12-14T17:44:39.996Z",
@@ -71395,7 +71395,7 @@ exports[`contentfulToDataset > the-example-app.json 3`] = `
   },
   {
     "_createdAt": "2017-11-08T16:06:56.098Z",
-    "_id": "drafts.2uNOpLMJioKeoMq8W44uYc",
+    "_id": "2uNOpLMJioKeoMq8W44uYc",
     "_rev": "2uNOpLMJioKeoMq8W44uYc",
     "_type": "layout",
     "_updatedAt": "2018-01-24T11:37:16.429Z",
@@ -73302,7 +73302,7 @@ exports[`contentfulToDataset > the-example-app.json 4`] = `
   },
   {
     "_createdAt": "2017-11-08T16:06:59.430Z",
-    "_id": "drafts.4ZQtjYftNKaoKWuksM0sS0",
+    "_id": "4ZQtjYftNKaoKWuksM0sS0",
     "_rev": "4ZQtjYftNKaoKWuksM0sS0",
     "_type": "lessonCopy",
     "_updatedAt": "2018-02-01T13:53:26.380Z",
@@ -73967,7 +73967,7 @@ exports[`contentfulToDataset > the-example-app.json 4`] = `
   },
   {
     "_createdAt": "2017-12-12T14:02:49.950Z",
-    "_id": "drafts.77NL8rGPks6SauGuoG8ui",
+    "_id": "77NL8rGPks6SauGuoG8ui",
     "_rev": "77NL8rGPks6SauGuoG8ui",
     "_type": "layoutHeroImage",
     "_updatedAt": "2017-12-14T17:44:39.996Z",
@@ -74465,7 +74465,7 @@ exports[`contentfulToDataset > the-example-app.json 4`] = `
   },
   {
     "_createdAt": "2017-11-08T16:06:56.098Z",
-    "_id": "drafts.2uNOpLMJioKeoMq8W44uYc",
+    "_id": "2uNOpLMJioKeoMq8W44uYc",
     "_rev": "2uNOpLMJioKeoMq8W44uYc",
     "_type": "layout",
     "_updatedAt": "2018-01-24T11:37:16.429Z",
@@ -74901,7 +74901,7 @@ let client = Client(spaceId: \\"<space_id>\\", accessToken: \\"<cpa_token>\\")",
   },
   {
     "_createdAt": "2017-11-08T16:06:59.430Z",
-    "_id": "drafts.4ZQtjYftNKaoKWuksM0sS0",
+    "_id": "4ZQtjYftNKaoKWuksM0sS0",
     "_rev": "4ZQtjYftNKaoKWuksM0sS0",
     "_type": "lessonCopy",
     "_updatedAt": "2018-02-01T13:53:26.380Z",
@@ -75034,7 +75034,7 @@ _The proceeding screenshot shows example validations within the Contentful web a
   },
   {
     "_createdAt": "2017-12-12T14:02:49.950Z",
-    "_id": "drafts.77NL8rGPks6SauGuoG8ui",
+    "_id": "77NL8rGPks6SauGuoG8ui",
     "_rev": "77NL8rGPks6SauGuoG8ui",
     "_type": "layoutHeroImage",
     "_updatedAt": "2017-12-14T17:44:39.996Z",
@@ -75396,7 +75396,7 @@ The Hello Contentful course covers the following topics:
   },
   {
     "_createdAt": "2017-11-08T16:06:56.098Z",
-    "_id": "drafts.2uNOpLMJioKeoMq8W44uYc",
+    "_id": "2uNOpLMJioKeoMq8W44uYc",
     "_rev": "2uNOpLMJioKeoMq8W44uYc",
     "_type": "layout",
     "_updatedAt": "2018-01-24T11:37:16.429Z",

--- a/src/test/__snapshots__/contentfulToDataset.test.ts.snap
+++ b/src/test/__snapshots__/contentfulToDataset.test.ts.snap
@@ -59869,6 +59869,18 @@ exports[`contentfulToDataset > the-example-app.json 1`] = `
         "_type": "reference",
         "_weak": false,
       },
+      {
+        "_ref": "drafts.77NL8rGPks6SauGuoG8ui",
+        "_strengthenOnPublish": {
+          "template": {
+            "id": "layoutHeroImage",
+            "params": {},
+          },
+          "type": "layoutHeroImage",
+        },
+        "_type": "reference",
+        "_weak": true,
+      },
     ],
     "slug": {
       "current": "home",
@@ -63193,6 +63205,18 @@ exports[`contentfulToDataset > the-example-app.json 2`] = `
         "_ref": "4B9n4zqG6QCgui8YiUs4Yc",
         "_type": "reference",
         "_weak": false,
+      },
+      {
+        "_ref": "drafts.77NL8rGPks6SauGuoG8ui",
+        "_strengthenOnPublish": {
+          "template": {
+            "id": "layoutHeroImage",
+            "params": {},
+          },
+          "type": "layoutHeroImage",
+        },
+        "_type": "reference",
+        "_weak": true,
       },
     ],
     "slug": {
@@ -68857,6 +68881,18 @@ exports[`contentfulToDataset > the-example-app.json 3`] = `
         "_type": "reference",
         "_weak": true,
       },
+      {
+        "_ref": "drafts.77NL8rGPks6SauGuoG8ui",
+        "_strengthenOnPublish": {
+          "template": {
+            "id": "layoutHeroImage",
+            "params": {},
+          },
+          "type": "layoutHeroImage",
+        },
+        "_type": "reference",
+        "_weak": true,
+      },
     ],
     "slug": {
       "current": "home",
@@ -72047,6 +72083,18 @@ exports[`contentfulToDataset > the-example-app.json 4`] = `
         "_type": "reference",
         "_weak": false,
       },
+      {
+        "_ref": "drafts.77NL8rGPks6SauGuoG8ui",
+        "_strengthenOnPublish": {
+          "template": {
+            "id": "layoutHeroImage",
+            "params": {},
+          },
+          "type": "layoutHeroImage",
+        },
+        "_type": "reference",
+        "_weak": true,
+      },
     ],
     "slug": {
       "current": "home",
@@ -75155,6 +75203,18 @@ For fun, change the formatting of **pizza** by going to \`API: Content Delivery 
         "_ref": "4B9n4zqG6QCgui8YiUs4Yc",
         "_type": "reference",
         "_weak": false,
+      },
+      {
+        "_ref": "drafts.77NL8rGPks6SauGuoG8ui",
+        "_strengthenOnPublish": {
+          "template": {
+            "id": "layoutHeroImage",
+            "params": {},
+          },
+          "type": "layoutHeroImage",
+        },
+        "_type": "reference",
+        "_weak": true,
       },
     ],
     "slug": {

--- a/src/test/__snapshots__/contentfulToDataset.test.ts.snap
+++ b/src/test/__snapshots__/contentfulToDataset.test.ts.snap
@@ -61631,7 +61631,7 @@ exports[`contentfulToDataset > the-example-app.json 1`] = `
   },
   {
     "_createdAt": "2017-11-08T16:06:59.430Z",
-    "_id": "4ZQtjYftNKaoKWuksM0sS0",
+    "_id": "drafts.4ZQtjYftNKaoKWuksM0sS0",
     "_rev": "4ZQtjYftNKaoKWuksM0sS0",
     "_type": "lessonCopy",
     "_updatedAt": "2018-02-01T13:53:26.380Z",
@@ -62296,7 +62296,7 @@ exports[`contentfulToDataset > the-example-app.json 1`] = `
   },
   {
     "_createdAt": "2017-12-12T14:02:49.950Z",
-    "_id": "77NL8rGPks6SauGuoG8ui",
+    "_id": "drafts.77NL8rGPks6SauGuoG8ui",
     "_rev": "77NL8rGPks6SauGuoG8ui",
     "_type": "layoutHeroImage",
     "_updatedAt": "2017-12-14T17:44:39.996Z",
@@ -62794,7 +62794,7 @@ exports[`contentfulToDataset > the-example-app.json 1`] = `
   },
   {
     "_createdAt": "2017-11-08T16:06:56.098Z",
-    "_id": "2uNOpLMJioKeoMq8W44uYc",
+    "_id": "drafts.2uNOpLMJioKeoMq8W44uYc",
     "_rev": "2uNOpLMJioKeoMq8W44uYc",
     "_type": "layout",
     "_updatedAt": "2018-01-24T11:37:16.429Z",
@@ -66204,12 +66204,12 @@ exports[`contentfulToDataset > the-example-app.json 2`] = `
     "__i18n_refs": [
       {
         "_key": "bb463b8b",
-        "_ref": "4ZQtjYftNKaoKWuksM0sS0__i18n_de-DE",
+        "_ref": "drafts.4ZQtjYftNKaoKWuksM0sS0__i18n_de-DE",
         "_type": "reference",
       },
     ],
     "_createdAt": "2017-11-08T16:06:59.430Z",
-    "_id": "4ZQtjYftNKaoKWuksM0sS0",
+    "_id": "drafts.4ZQtjYftNKaoKWuksM0sS0",
     "_rev": "4ZQtjYftNKaoKWuksM0sS0",
     "_type": "lessonCopy",
     "_updatedAt": "2018-02-01T13:53:26.380Z",
@@ -66303,12 +66303,12 @@ exports[`contentfulToDataset > the-example-app.json 2`] = `
   },
   {
     "__i18n_base": {
-      "_ref": "4ZQtjYftNKaoKWuksM0sS0",
+      "_ref": "drafts.4ZQtjYftNKaoKWuksM0sS0",
       "_type": "reference",
     },
     "__i18n_lang": "de-DE",
     "_createdAt": "2017-11-08T16:06:59.430Z",
-    "_id": "4ZQtjYftNKaoKWuksM0sS0",
+    "_id": "drafts.4ZQtjYftNKaoKWuksM0sS0",
     "_rev": "4ZQtjYftNKaoKWuksM0sS0",
     "_type": "lessonCopy",
     "_updatedAt": "2018-02-01T13:53:26.380Z",
@@ -67376,12 +67376,12 @@ exports[`contentfulToDataset > the-example-app.json 2`] = `
     "__i18n_refs": [
       {
         "_key": "bb463b8b",
-        "_ref": "77NL8rGPks6SauGuoG8ui__i18n_de-DE",
+        "_ref": "drafts.77NL8rGPks6SauGuoG8ui__i18n_de-DE",
         "_type": "reference",
       },
     ],
     "_createdAt": "2017-12-12T14:02:49.950Z",
-    "_id": "77NL8rGPks6SauGuoG8ui",
+    "_id": "drafts.77NL8rGPks6SauGuoG8ui",
     "_rev": "77NL8rGPks6SauGuoG8ui",
     "_type": "layoutHeroImage",
     "_updatedAt": "2017-12-14T17:44:39.996Z",
@@ -67394,12 +67394,12 @@ exports[`contentfulToDataset > the-example-app.json 2`] = `
   },
   {
     "__i18n_base": {
-      "_ref": "77NL8rGPks6SauGuoG8ui",
+      "_ref": "drafts.77NL8rGPks6SauGuoG8ui",
       "_type": "reference",
     },
     "__i18n_lang": "de-DE",
     "_createdAt": "2017-12-12T14:02:49.950Z",
-    "_id": "77NL8rGPks6SauGuoG8ui",
+    "_id": "drafts.77NL8rGPks6SauGuoG8ui",
     "_rev": "77NL8rGPks6SauGuoG8ui",
     "_type": "layoutHeroImage",
     "_updatedAt": "2017-12-14T17:44:39.996Z",
@@ -68308,12 +68308,12 @@ exports[`contentfulToDataset > the-example-app.json 2`] = `
     "__i18n_refs": [
       {
         "_key": "bb463b8b",
-        "_ref": "2uNOpLMJioKeoMq8W44uYc__i18n_de-DE",
+        "_ref": "drafts.2uNOpLMJioKeoMq8W44uYc__i18n_de-DE",
         "_type": "reference",
       },
     ],
     "_createdAt": "2017-11-08T16:06:56.098Z",
-    "_id": "2uNOpLMJioKeoMq8W44uYc",
+    "_id": "drafts.2uNOpLMJioKeoMq8W44uYc",
     "_rev": "2uNOpLMJioKeoMq8W44uYc",
     "_type": "layout",
     "_updatedAt": "2018-01-24T11:37:16.429Z",
@@ -68336,12 +68336,12 @@ exports[`contentfulToDataset > the-example-app.json 2`] = `
   },
   {
     "__i18n_base": {
-      "_ref": "2uNOpLMJioKeoMq8W44uYc",
+      "_ref": "drafts.2uNOpLMJioKeoMq8W44uYc",
       "_type": "reference",
     },
     "__i18n_lang": "de-DE",
     "_createdAt": "2017-11-08T16:06:56.098Z",
-    "_id": "2uNOpLMJioKeoMq8W44uYc",
+    "_id": "drafts.2uNOpLMJioKeoMq8W44uYc",
     "_rev": "2uNOpLMJioKeoMq8W44uYc",
     "_type": "layout",
     "_updatedAt": "2018-01-24T11:37:16.429Z",
@@ -70232,7 +70232,7 @@ exports[`contentfulToDataset > the-example-app.json 3`] = `
   },
   {
     "_createdAt": "2017-11-08T16:06:59.430Z",
-    "_id": "4ZQtjYftNKaoKWuksM0sS0",
+    "_id": "drafts.4ZQtjYftNKaoKWuksM0sS0",
     "_rev": "4ZQtjYftNKaoKWuksM0sS0",
     "_type": "lessonCopy",
     "_updatedAt": "2018-02-01T13:53:26.380Z",
@@ -70897,7 +70897,7 @@ exports[`contentfulToDataset > the-example-app.json 3`] = `
   },
   {
     "_createdAt": "2017-12-12T14:02:49.950Z",
-    "_id": "77NL8rGPks6SauGuoG8ui",
+    "_id": "drafts.77NL8rGPks6SauGuoG8ui",
     "_rev": "77NL8rGPks6SauGuoG8ui",
     "_type": "layoutHeroImage",
     "_updatedAt": "2017-12-14T17:44:39.996Z",
@@ -71395,7 +71395,7 @@ exports[`contentfulToDataset > the-example-app.json 3`] = `
   },
   {
     "_createdAt": "2017-11-08T16:06:56.098Z",
-    "_id": "2uNOpLMJioKeoMq8W44uYc",
+    "_id": "drafts.2uNOpLMJioKeoMq8W44uYc",
     "_rev": "2uNOpLMJioKeoMq8W44uYc",
     "_type": "layout",
     "_updatedAt": "2018-01-24T11:37:16.429Z",
@@ -73302,7 +73302,7 @@ exports[`contentfulToDataset > the-example-app.json 4`] = `
   },
   {
     "_createdAt": "2017-11-08T16:06:59.430Z",
-    "_id": "4ZQtjYftNKaoKWuksM0sS0",
+    "_id": "drafts.4ZQtjYftNKaoKWuksM0sS0",
     "_rev": "4ZQtjYftNKaoKWuksM0sS0",
     "_type": "lessonCopy",
     "_updatedAt": "2018-02-01T13:53:26.380Z",
@@ -73967,7 +73967,7 @@ exports[`contentfulToDataset > the-example-app.json 4`] = `
   },
   {
     "_createdAt": "2017-12-12T14:02:49.950Z",
-    "_id": "77NL8rGPks6SauGuoG8ui",
+    "_id": "drafts.77NL8rGPks6SauGuoG8ui",
     "_rev": "77NL8rGPks6SauGuoG8ui",
     "_type": "layoutHeroImage",
     "_updatedAt": "2017-12-14T17:44:39.996Z",
@@ -74465,7 +74465,7 @@ exports[`contentfulToDataset > the-example-app.json 4`] = `
   },
   {
     "_createdAt": "2017-11-08T16:06:56.098Z",
-    "_id": "2uNOpLMJioKeoMq8W44uYc",
+    "_id": "drafts.2uNOpLMJioKeoMq8W44uYc",
     "_rev": "2uNOpLMJioKeoMq8W44uYc",
     "_type": "layout",
     "_updatedAt": "2018-01-24T11:37:16.429Z",
@@ -74901,7 +74901,7 @@ let client = Client(spaceId: \\"<space_id>\\", accessToken: \\"<cpa_token>\\")",
   },
   {
     "_createdAt": "2017-11-08T16:06:59.430Z",
-    "_id": "4ZQtjYftNKaoKWuksM0sS0",
+    "_id": "drafts.4ZQtjYftNKaoKWuksM0sS0",
     "_rev": "4ZQtjYftNKaoKWuksM0sS0",
     "_type": "lessonCopy",
     "_updatedAt": "2018-02-01T13:53:26.380Z",
@@ -75034,7 +75034,7 @@ _The proceeding screenshot shows example validations within the Contentful web a
   },
   {
     "_createdAt": "2017-12-12T14:02:49.950Z",
-    "_id": "77NL8rGPks6SauGuoG8ui",
+    "_id": "drafts.77NL8rGPks6SauGuoG8ui",
     "_rev": "77NL8rGPks6SauGuoG8ui",
     "_type": "layoutHeroImage",
     "_updatedAt": "2017-12-14T17:44:39.996Z",
@@ -75396,7 +75396,7 @@ The Hello Contentful course covers the following topics:
   },
   {
     "_createdAt": "2017-11-08T16:06:56.098Z",
-    "_id": "2uNOpLMJioKeoMq8W44uYc",
+    "_id": "drafts.2uNOpLMJioKeoMq8W44uYc",
     "_rev": "2uNOpLMJioKeoMq8W44uYc",
     "_type": "layout",
     "_updatedAt": "2018-01-24T11:37:16.429Z",

--- a/src/test/__snapshots__/contentfulToDataset.test.ts.snap
+++ b/src/test/__snapshots__/contentfulToDataset.test.ts.snap
@@ -59751,6 +59751,131 @@ exports[`contentfulToDataset > sveltekit.json 5`] = `
 exports[`contentfulToDataset > the-example-app.json 1`] = `
 [
   {
+    "_createdAt": "2017-11-08T16:06:59.430Z",
+    "_id": "drafts.4ZQtjYftNKaoKWuksM0sS0",
+    "_rev": "4ZQtjYftNKaoKWuksM0sS0",
+    "_type": "lessonCopy",
+    "_updatedAt": "2018-02-01T13:53:26.380Z",
+    "copy": [
+      {
+        "_key": "bb463b8b",
+        "_type": "block",
+        "children": [
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": "The example app is configured to connect to both the Delivery API and the Preview API.",
+          },
+        ],
+        "markDefs": [],
+        "style": "normal",
+      },
+      {
+        "_key": "bb463b8b",
+        "_type": "block",
+        "children": [
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": "For fun, change the formatting of ",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [
+              "a27218b8",
+            ],
+            "text": "pizza",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": " by going to ",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [
+              "a27218b8",
+            ],
+            "text": "API: Content Delivery API",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": " in the top menu bar and selecting ",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [
+              "a27218b8",
+            ],
+            "text": "API: Content Preview API",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+          },
+        ],
+        "markDefs": [],
+        "style": "normal",
+      },
+      {
+        "_key": "bb463b8b",
+        "_type": "block",
+        "children": [
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": "Note: The Content Preview API is not behind a CDN cache and hence might take a short moment to load for you.",
+          },
+        ],
+        "markDefs": [],
+        "style": "blockquote",
+      },
+    ],
+    "title": "Fetch draft content > footnote",
+  },
+  {
+    "_createdAt": "2017-12-12T14:02:49.950Z",
+    "_id": "drafts.77NL8rGPks6SauGuoG8ui",
+    "_rev": "77NL8rGPks6SauGuoG8ui",
+    "_type": "layoutHeroImage",
+    "_updatedAt": "2017-12-14T17:44:39.996Z",
+    "backgroundImage": {
+      "_sanityAsset": "image@https://images.contentful.com/qz0n5cdakyl9/4dgP2U7BeMuk0icguS4qGw/52cdd3491ac9824da1b1ae2c51a6c30c/Contentful_team.png",
+      "_type": "image",
+    },
+    "headline": "Greetings from Contentful",
+    "title": "Home > Hero image",
+  },
+  {
+    "_createdAt": "2017-11-08T16:06:56.098Z",
+    "_id": "drafts.2uNOpLMJioKeoMq8W44uYc",
+    "_rev": "2uNOpLMJioKeoMq8W44uYc",
+    "_type": "layout",
+    "_updatedAt": "2018-01-24T11:37:16.429Z",
+    "contentModules": [
+      {
+        "_ref": "4B9n4zqG6QCgui8YiUs4Yc",
+        "_type": "reference",
+        "_weak": false,
+      },
+    ],
+    "slug": {
+      "current": "home",
+    },
+    "title": "Home",
+  },
+  {
     "_createdAt": "2017-11-08T16:06:55.505Z",
     "_id": "7JhDodrNmwmwGmQqiACW4",
     "_rev": "7JhDodrNmwmwGmQqiACW4",
@@ -62804,11 +62929,6 @@ exports[`contentfulToDataset > the-example-app.json 1`] = `
         "_type": "reference",
         "_weak": false,
       },
-      {
-        "_ref": "77NL8rGPks6SauGuoG8ui",
-        "_type": "reference",
-        "_weak": false,
-      },
     ],
     "slug": {
       "current": "home",
@@ -62820,6 +62940,278 @@ exports[`contentfulToDataset > the-example-app.json 1`] = `
 
 exports[`contentfulToDataset > the-example-app.json 2`] = `
 [
+  {
+    "__i18n_lang": "en-US",
+    "__i18n_refs": [
+      {
+        "_key": "bb463b8b",
+        "_ref": "drafts.4ZQtjYftNKaoKWuksM0sS0__i18n_de-DE",
+        "_type": "reference",
+      },
+    ],
+    "_createdAt": "2017-11-08T16:06:59.430Z",
+    "_id": "drafts.4ZQtjYftNKaoKWuksM0sS0",
+    "_rev": "4ZQtjYftNKaoKWuksM0sS0",
+    "_type": "lessonCopy",
+    "_updatedAt": "2018-02-01T13:53:26.380Z",
+    "copy": [
+      {
+        "_key": "bb463b8b",
+        "_type": "block",
+        "children": [
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": "The example app is configured to connect to both the Delivery API and the Preview API.",
+          },
+        ],
+        "markDefs": [],
+        "style": "normal",
+      },
+      {
+        "_key": "bb463b8b",
+        "_type": "block",
+        "children": [
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": "For fun, change the formatting of ",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [
+              "a27218b8",
+            ],
+            "text": "pizza",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": " by going to ",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [
+              "a27218b8",
+            ],
+            "text": "API: Content Delivery API",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": " in the top menu bar and selecting ",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [
+              "a27218b8",
+            ],
+            "text": "API: Content Preview API",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+          },
+        ],
+        "markDefs": [],
+        "style": "normal",
+      },
+      {
+        "_key": "bb463b8b",
+        "_type": "block",
+        "children": [
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": "Note: The Content Preview API is not behind a CDN cache and hence might take a short moment to load for you.",
+          },
+        ],
+        "markDefs": [],
+        "style": "blockquote",
+      },
+    ],
+    "title": "Fetch draft content > footnote",
+  },
+  {
+    "__i18n_base": {
+      "_ref": "drafts.4ZQtjYftNKaoKWuksM0sS0",
+      "_type": "reference",
+    },
+    "__i18n_lang": "de-DE",
+    "_createdAt": "2017-11-08T16:06:59.430Z",
+    "_id": "drafts.4ZQtjYftNKaoKWuksM0sS0",
+    "_rev": "4ZQtjYftNKaoKWuksM0sS0",
+    "_type": "lessonCopy",
+    "_updatedAt": "2018-02-01T13:53:26.380Z",
+    "copy": [
+      {
+        "_key": "bb463b8b",
+        "_type": "block",
+        "children": [
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": "Diese Beispielanwendung is so konfiguriert worden, dass sie sich sowohl mit der Deliver API als auch der Preview API verbinden kann.",
+          },
+        ],
+        "markDefs": [],
+        "style": "normal",
+      },
+      {
+        "_key": "bb463b8b",
+        "_type": "block",
+        "children": [
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": "Zum Spaß können Sie die Formatierung des Wortes ",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [
+              "a27218b8",
+            ],
+            "text": "Pizza",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": " ändern, indem Sie im oberen Menü die Auswahl von ",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [
+              "a27218b8",
+            ],
+            "text": "API: Preview (unveröffentlichter Inhalt)",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": " auf ",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [
+              "a27218b8",
+            ],
+            "text": "API: Delivery (veröffentlichter Inhalt)",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": " ändern.",
+          },
+        ],
+        "markDefs": [],
+        "style": "normal",
+      },
+      {
+        "_key": "bb463b8b",
+        "_type": "block",
+        "children": [
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": "Hinweis: Die Content Preview API ist nicht hinter einem Cache und daher etwas langsamer als die Delivery API.",
+          },
+        ],
+        "markDefs": [],
+        "style": "blockquote",
+      },
+    ],
+  },
+  {
+    "__i18n_lang": "en-US",
+    "__i18n_refs": [
+      {
+        "_key": "bb463b8b",
+        "_ref": "drafts.77NL8rGPks6SauGuoG8ui__i18n_de-DE",
+        "_type": "reference",
+      },
+    ],
+    "_createdAt": "2017-12-12T14:02:49.950Z",
+    "_id": "drafts.77NL8rGPks6SauGuoG8ui",
+    "_rev": "77NL8rGPks6SauGuoG8ui",
+    "_type": "layoutHeroImage",
+    "_updatedAt": "2017-12-14T17:44:39.996Z",
+    "backgroundImage": {
+      "_sanityAsset": "image@https://images.contentful.com/qz0n5cdakyl9/4dgP2U7BeMuk0icguS4qGw/52cdd3491ac9824da1b1ae2c51a6c30c/Contentful_team.png",
+      "_type": "image",
+    },
+    "headline": "Greetings from Contentful",
+    "title": "Home > Hero image",
+  },
+  {
+    "__i18n_base": {
+      "_ref": "drafts.77NL8rGPks6SauGuoG8ui",
+      "_type": "reference",
+    },
+    "__i18n_lang": "de-DE",
+    "_createdAt": "2017-12-12T14:02:49.950Z",
+    "_id": "drafts.77NL8rGPks6SauGuoG8ui",
+    "_rev": "77NL8rGPks6SauGuoG8ui",
+    "_type": "layoutHeroImage",
+    "_updatedAt": "2017-12-14T17:44:39.996Z",
+    "headline": "Grüße von Contentful",
+  },
+  {
+    "__i18n_lang": "en-US",
+    "__i18n_refs": [
+      {
+        "_key": "bb463b8b",
+        "_ref": "drafts.2uNOpLMJioKeoMq8W44uYc__i18n_de-DE",
+        "_type": "reference",
+      },
+    ],
+    "_createdAt": "2017-11-08T16:06:56.098Z",
+    "_id": "drafts.2uNOpLMJioKeoMq8W44uYc",
+    "_rev": "2uNOpLMJioKeoMq8W44uYc",
+    "_type": "layout",
+    "_updatedAt": "2018-01-24T11:37:16.429Z",
+    "contentModules": [
+      {
+        "_ref": "4B9n4zqG6QCgui8YiUs4Yc",
+        "_type": "reference",
+        "_weak": false,
+      },
+    ],
+    "slug": {
+      "current": "home",
+    },
+    "title": "Home",
+  },
+  {
+    "__i18n_base": {
+      "_ref": "drafts.2uNOpLMJioKeoMq8W44uYc",
+      "_type": "reference",
+    },
+    "__i18n_lang": "de-DE",
+    "_createdAt": "2017-11-08T16:06:56.098Z",
+    "_id": "drafts.2uNOpLMJioKeoMq8W44uYc",
+    "_rev": "2uNOpLMJioKeoMq8W44uYc",
+    "_type": "layout",
+    "_updatedAt": "2018-01-24T11:37:16.429Z",
+  },
   {
     "__i18n_lang": "en-US",
     "__i18n_refs": [
@@ -68323,11 +68715,6 @@ exports[`contentfulToDataset > the-example-app.json 2`] = `
         "_type": "reference",
         "_weak": false,
       },
-      {
-        "_ref": "77NL8rGPks6SauGuoG8ui",
-        "_type": "reference",
-        "_weak": false,
-      },
     ],
     "slug": {
       "current": "home",
@@ -68351,6 +68738,131 @@ exports[`contentfulToDataset > the-example-app.json 2`] = `
 
 exports[`contentfulToDataset > the-example-app.json 3`] = `
 [
+  {
+    "_createdAt": "2017-11-08T16:06:59.430Z",
+    "_id": "drafts.4ZQtjYftNKaoKWuksM0sS0",
+    "_rev": "4ZQtjYftNKaoKWuksM0sS0",
+    "_type": "lessonCopy",
+    "_updatedAt": "2018-02-01T13:53:26.380Z",
+    "copy": [
+      {
+        "_key": "bb463b8b",
+        "_type": "block",
+        "children": [
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": "The example app is configured to connect to both the Delivery API and the Preview API.",
+          },
+        ],
+        "markDefs": [],
+        "style": "normal",
+      },
+      {
+        "_key": "bb463b8b",
+        "_type": "block",
+        "children": [
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": "For fun, change the formatting of ",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [
+              "a27218b8",
+            ],
+            "text": "pizza",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": " by going to ",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [
+              "a27218b8",
+            ],
+            "text": "API: Content Delivery API",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": " in the top menu bar and selecting ",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [
+              "a27218b8",
+            ],
+            "text": "API: Content Preview API",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+          },
+        ],
+        "markDefs": [],
+        "style": "normal",
+      },
+      {
+        "_key": "bb463b8b",
+        "_type": "block",
+        "children": [
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": "Note: The Content Preview API is not behind a CDN cache and hence might take a short moment to load for you.",
+          },
+        ],
+        "markDefs": [],
+        "style": "blockquote",
+      },
+    ],
+    "title": "Fetch draft content > footnote",
+  },
+  {
+    "_createdAt": "2017-12-12T14:02:49.950Z",
+    "_id": "drafts.77NL8rGPks6SauGuoG8ui",
+    "_rev": "77NL8rGPks6SauGuoG8ui",
+    "_type": "layoutHeroImage",
+    "_updatedAt": "2017-12-14T17:44:39.996Z",
+    "backgroundImage": {
+      "_sanityAsset": "image@https://images.contentful.com/qz0n5cdakyl9/4dgP2U7BeMuk0icguS4qGw/52cdd3491ac9824da1b1ae2c51a6c30c/Contentful_team.png",
+      "_type": "image",
+    },
+    "headline": "Greetings from Contentful",
+    "title": "Home > Hero image",
+  },
+  {
+    "_createdAt": "2017-11-08T16:06:56.098Z",
+    "_id": "drafts.2uNOpLMJioKeoMq8W44uYc",
+    "_rev": "2uNOpLMJioKeoMq8W44uYc",
+    "_type": "layout",
+    "_updatedAt": "2018-01-24T11:37:16.429Z",
+    "contentModules": [
+      {
+        "_ref": "4B9n4zqG6QCgui8YiUs4Yc",
+        "_type": "reference",
+        "_weak": true,
+      },
+    ],
+    "slug": {
+      "current": "home",
+    },
+    "title": "Home",
+  },
   {
     "_createdAt": "2017-11-08T16:06:55.505Z",
     "_id": "7JhDodrNmwmwGmQqiACW4",
@@ -71405,11 +71917,6 @@ exports[`contentfulToDataset > the-example-app.json 3`] = `
         "_type": "reference",
         "_weak": true,
       },
-      {
-        "_ref": "77NL8rGPks6SauGuoG8ui",
-        "_type": "reference",
-        "_weak": true,
-      },
     ],
     "slug": {
       "current": "home",
@@ -71421,6 +71928,131 @@ exports[`contentfulToDataset > the-example-app.json 3`] = `
 
 exports[`contentfulToDataset > the-example-app.json 4`] = `
 [
+  {
+    "_createdAt": "2017-11-08T16:06:59.430Z",
+    "_id": "drafts.4ZQtjYftNKaoKWuksM0sS0",
+    "_rev": "4ZQtjYftNKaoKWuksM0sS0",
+    "_type": "lessonCopy",
+    "_updatedAt": "2018-02-01T13:53:26.380Z",
+    "copy": [
+      {
+        "_key": "bb463b8b",
+        "_type": "block",
+        "children": [
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": "The example app is configured to connect to both the Delivery API and the Preview API.",
+          },
+        ],
+        "markDefs": [],
+        "style": "normal",
+      },
+      {
+        "_key": "bb463b8b",
+        "_type": "block",
+        "children": [
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": "For fun, change the formatting of ",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [
+              "a27218b8",
+            ],
+            "text": "pizza",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": " by going to ",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [
+              "a27218b8",
+            ],
+            "text": "API: Content Delivery API",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": " in the top menu bar and selecting ",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [
+              "a27218b8",
+            ],
+            "text": "API: Content Preview API",
+          },
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": ".",
+          },
+        ],
+        "markDefs": [],
+        "style": "normal",
+      },
+      {
+        "_key": "bb463b8b",
+        "_type": "block",
+        "children": [
+          {
+            "_key": "bb463b8b",
+            "_type": "span",
+            "marks": [],
+            "text": "Note: The Content Preview API is not behind a CDN cache and hence might take a short moment to load for you.",
+          },
+        ],
+        "markDefs": [],
+        "style": "blockquote",
+      },
+    ],
+    "title": "Fetch draft content > footnote",
+  },
+  {
+    "_createdAt": "2017-12-12T14:02:49.950Z",
+    "_id": "drafts.77NL8rGPks6SauGuoG8ui",
+    "_rev": "77NL8rGPks6SauGuoG8ui",
+    "_type": "layoutHeroImage",
+    "_updatedAt": "2017-12-14T17:44:39.996Z",
+    "backgroundImage": {
+      "_sanityAsset": "image@https://images.contentful.com/qz0n5cdakyl9/4dgP2U7BeMuk0icguS4qGw/52cdd3491ac9824da1b1ae2c51a6c30c/Contentful_team.png",
+      "_type": "image",
+    },
+    "headline": "Greetings from Contentful",
+    "title": "Home > Hero image",
+  },
+  {
+    "_createdAt": "2017-11-08T16:06:56.098Z",
+    "_id": "drafts.2uNOpLMJioKeoMq8W44uYc",
+    "_rev": "2uNOpLMJioKeoMq8W44uYc",
+    "_type": "layout",
+    "_updatedAt": "2018-01-24T11:37:16.429Z",
+    "contentModules": [
+      {
+        "_ref": "4B9n4zqG6QCgui8YiUs4Yc",
+        "_type": "reference",
+        "_weak": false,
+      },
+    ],
+    "slug": {
+      "current": "home",
+    },
+    "title": "Home",
+  },
   {
     "_createdAt": "2017-11-08T16:06:55.505Z",
     "_id": "7JhDodrNmwmwGmQqiACW4",
@@ -74475,11 +75107,6 @@ exports[`contentfulToDataset > the-example-app.json 4`] = `
         "_type": "reference",
         "_weak": false,
       },
-      {
-        "_ref": "77NL8rGPks6SauGuoG8ui",
-        "_type": "reference",
-        "_weak": false,
-      },
     ],
     "slug": {
       "current": "home",
@@ -74491,6 +75118,50 @@ exports[`contentfulToDataset > the-example-app.json 4`] = `
 
 exports[`contentfulToDataset > the-example-app.json 5`] = `
 [
+  {
+    "_createdAt": "2017-11-08T16:06:59.430Z",
+    "_id": "drafts.4ZQtjYftNKaoKWuksM0sS0",
+    "_rev": "4ZQtjYftNKaoKWuksM0sS0",
+    "_type": "lessonCopy",
+    "_updatedAt": "2018-02-01T13:53:26.380Z",
+    "copy": "The example app is configured to connect to both the Delivery API and the Preview API. 
+
+For fun, change the formatting of **pizza** by going to \`API: Content Delivery API\` in the top menu bar and selecting \`API: Content Preview API\`.
+
+> Note: The Content Preview API is not behind a CDN cache and hence might take a short moment to load for you.",
+    "title": "Fetch draft content > footnote",
+  },
+  {
+    "_createdAt": "2017-12-12T14:02:49.950Z",
+    "_id": "drafts.77NL8rGPks6SauGuoG8ui",
+    "_rev": "77NL8rGPks6SauGuoG8ui",
+    "_type": "layoutHeroImage",
+    "_updatedAt": "2017-12-14T17:44:39.996Z",
+    "backgroundImage": {
+      "_sanityAsset": "image@https://images.contentful.com/qz0n5cdakyl9/4dgP2U7BeMuk0icguS4qGw/52cdd3491ac9824da1b1ae2c51a6c30c/Contentful_team.png",
+      "_type": "image",
+    },
+    "headline": "Greetings from Contentful",
+    "title": "Home > Hero image",
+  },
+  {
+    "_createdAt": "2017-11-08T16:06:56.098Z",
+    "_id": "drafts.2uNOpLMJioKeoMq8W44uYc",
+    "_rev": "2uNOpLMJioKeoMq8W44uYc",
+    "_type": "layout",
+    "_updatedAt": "2018-01-24T11:37:16.429Z",
+    "contentModules": [
+      {
+        "_ref": "4B9n4zqG6QCgui8YiUs4Yc",
+        "_type": "reference",
+        "_weak": false,
+      },
+    ],
+    "slug": {
+      "current": "home",
+    },
+    "title": "Home",
+  },
   {
     "_createdAt": "2017-11-08T16:06:55.505Z",
     "_id": "7JhDodrNmwmwGmQqiACW4",
@@ -75403,11 +76074,6 @@ The Hello Contentful course covers the following topics:
     "contentModules": [
       {
         "_ref": "4B9n4zqG6QCgui8YiUs4Yc",
-        "_type": "reference",
-        "_weak": false,
-      },
-      {
-        "_ref": "77NL8rGPks6SauGuoG8ui",
         "_type": "reference",
         "_weak": false,
       },

--- a/src/test/contentfulToDataset.test.ts
+++ b/src/test/contentfulToDataset.test.ts
@@ -43,19 +43,29 @@ describe('contentfulToDataset', () => {
   test('blog.json', async () => {
     const {default: data} = await import('./fixtures/blog.json')
     expect(
-      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, smOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, imOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, wkOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, pathOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, mdOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
   })
 
@@ -63,342 +73,522 @@ describe('contentfulToDataset', () => {
   test('11ty.json', async () => {
     const {default: data} = await import('./fixtures/11ty.json')
     expect(
-      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, smOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, imOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, wkOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, pathOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, mdOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/content-models/blob/fcac5d461c2c8cb95800eb745974aa0d282c3583/blog/contentful-export.json
   test('complex-blog.json', async () => {
     const {default: data} = await import('./fixtures/complex-blog.json')
     expect(
-      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, smOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, imOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, wkOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, pathOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, mdOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/content-models/blob/fcac5d461c2c8cb95800eb745974aa0d282c3583/gallery/contentful-export.json
   test('gallery.json', async () => {
     const {default: data} = await import('./fixtures/gallery.json')
     expect(
-      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, smOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, imOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, wkOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, pathOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, mdOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/content-models/blob/fcac5d461c2c8cb95800eb745974aa0d282c3583/product-catalogue/product-catalog.json
   test('product-catalogue.json', async () => {
     const {default: data} = await import('./fixtures/product-catalogue.json')
     expect(
-      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, smOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, imOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, wkOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, pathOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, mdOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/content-models/blob/fcac5d461c2c8cb95800eb745974aa0d282c3583/the-example-app/contentful-export.json
   test('the-example-app.json', async () => {
     const {default: data} = await import('./fixtures/the-example-app.json')
     expect(
-      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, smOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, imOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, wkOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, pathOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, mdOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/contentful-ls-cma-1/blob/761dda7a59e81102c4c7cb2c73e7a3d800ee8878/clover-export.json
   test('ls-cma-1.json', async () => {
     const {default: data} = await import('./fixtures/ls-cma-1.json')
     expect(
-      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, smOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, imOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, wkOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, pathOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, mdOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/ls-categories/blob/49a5c36bb2ab844207d0b64584439debe3bac4fd/categories-demo-export.json
   test('categories-demo-export.json', async () => {
     const {default: data} = await import('./fixtures/categories-demo-export.json')
     expect(
-      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, smOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, imOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, wkOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, pathOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, mdOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/ls-jumpstart-shop/blob/b5c4cbf2211dd9c1040ef80eb503d0898af4512e/space-export/space_old.json
   test('jumpstart-shop.json', async () => {
     const {default: data} = await import('./fixtures/jumpstart-shop.json')
     expect(
-      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, smOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, imOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, wkOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, pathOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, mdOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/ls-workflows/blob/ef2654c7a4492517807d707a93a7b407652c5108/contentful-workflow-export.json
   test('workflow.json', async () => {
     const {default: data} = await import('./fixtures/workflow.json')
     expect(
-      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, smOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, imOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, wkOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, pathOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, mdOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/react-starter/blob/2c40987790d22dcf9876d09cd621e82131371964/contentful/export.json
   test('react-starter.json', async () => {
     const {default: data} = await import('./fixtures/react-starter.json')
     expect(
-      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, smOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, imOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, wkOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, pathOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, mdOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/starter-gatsby-blog/blob/4dc30e2621adbc10177d1ccbee518c6fcee70a60/contentful/export.json
   test('gatsby-blog.json', async () => {
     const {default: data} = await import('./fixtures/gatsby-blog.json')
     expect(
-      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, smOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, imOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, wkOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, pathOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, mdOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/starter-hydrogen-store/blob/6bc733608fc1e8c961c0cca654eaf44636571cc5/contentful-export.json
   test('hydrogen-store.json', async () => {
     const {default: data} = await import('./fixtures/hydrogen-store.json')
     expect(
-      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, smOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, imOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, wkOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, pathOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, mdOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/starter-javascript-cookbook/blob/8c3655b1b1d29458d5a84da31e39753ab6ee8233/contentful/export.json
   test('cookbook.json', async () => {
     const {default: data} = await import('./fixtures/cookbook.json')
     expect(
-      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, smOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, imOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, wkOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, pathOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, mdOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/starter-remix-portfolio/blob/fce56f371bfce44ca69aeffa54428f6f9f589d98/remix.init/contentful/export.json
   test('remix.json', async () => {
     const {default: data} = await import('./fixtures/remix.json')
     expect(
-      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, smOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, imOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, wkOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, pathOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, mdOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/starters/blob/867272460e3d1e20daf5d856fa7411d96978ff83/examples/gatsby-blog/contentful/export.json
   test('gatsby-blog2.json', async () => {
     const {default: data} = await import('./fixtures/gatsby-blog2.json')
     expect(
-      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, smOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, imOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, wkOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, pathOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, mdOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/starters/blob/867272460e3d1e20daf5d856fa7411d96978ff83/examples/knowledge-base/contentful/export.json
   test('knowledge-base.json', async () => {
     const {default: data} = await import('./fixtures/knowledge-base.json')
     expect(
-      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, smOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, imOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, wkOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, pathOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, mdOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/starters/blob/867272460e3d1e20daf5d856fa7411d96978ff83/examples/next.js-blog/contentful/export.json
   test('nextjs.json', async () => {
     const {default: data} = await import('./fixtures/nextjs.json')
     expect(
-      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, smOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, imOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, wkOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, pathOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, mdOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/sveltekit-starter/blob/4dc8afe9701a36e455f5545914633648bf630372/contentful/export.json
   test('sveltekit.json', async () => {
     const {default: data} = await import('./fixtures/sveltekit.json')
     expect(
-      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, smOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, imOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, wkOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, pathOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({drafts: data as any, published: data as any}, mdOptions))
+        .split('\n')
+        .map(parse),
     ).toMatchSnapshot()
   })
 })

--- a/src/test/contentfulToDataset.test.ts
+++ b/src/test/contentfulToDataset.test.ts
@@ -43,19 +43,19 @@ describe('contentfulToDataset', () => {
   test('blog.json', async () => {
     const {default: data} = await import('./fixtures/blog.json')
     expect(
-      (await contentfulToDataset(data as any, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
   })
 
@@ -63,342 +63,342 @@ describe('contentfulToDataset', () => {
   test('11ty.json', async () => {
     const {default: data} = await import('./fixtures/11ty.json')
     expect(
-      (await contentfulToDataset(data as any, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/content-models/blob/fcac5d461c2c8cb95800eb745974aa0d282c3583/blog/contentful-export.json
   test('complex-blog.json', async () => {
     const {default: data} = await import('./fixtures/complex-blog.json')
     expect(
-      (await contentfulToDataset(data as any, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/content-models/blob/fcac5d461c2c8cb95800eb745974aa0d282c3583/gallery/contentful-export.json
   test('gallery.json', async () => {
     const {default: data} = await import('./fixtures/gallery.json')
     expect(
-      (await contentfulToDataset(data as any, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/content-models/blob/fcac5d461c2c8cb95800eb745974aa0d282c3583/product-catalogue/product-catalog.json
   test('product-catalogue.json', async () => {
     const {default: data} = await import('./fixtures/product-catalogue.json')
     expect(
-      (await contentfulToDataset(data as any, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/content-models/blob/fcac5d461c2c8cb95800eb745974aa0d282c3583/the-example-app/contentful-export.json
   test('the-example-app.json', async () => {
     const {default: data} = await import('./fixtures/the-example-app.json')
     expect(
-      (await contentfulToDataset(data as any, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/contentful-ls-cma-1/blob/761dda7a59e81102c4c7cb2c73e7a3d800ee8878/clover-export.json
   test('ls-cma-1.json', async () => {
     const {default: data} = await import('./fixtures/ls-cma-1.json')
     expect(
-      (await contentfulToDataset(data as any, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/ls-categories/blob/49a5c36bb2ab844207d0b64584439debe3bac4fd/categories-demo-export.json
   test('categories-demo-export.json', async () => {
     const {default: data} = await import('./fixtures/categories-demo-export.json')
     expect(
-      (await contentfulToDataset(data as any, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/ls-jumpstart-shop/blob/b5c4cbf2211dd9c1040ef80eb503d0898af4512e/space-export/space_old.json
   test('jumpstart-shop.json', async () => {
     const {default: data} = await import('./fixtures/jumpstart-shop.json')
     expect(
-      (await contentfulToDataset(data as any, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/ls-workflows/blob/ef2654c7a4492517807d707a93a7b407652c5108/contentful-workflow-export.json
   test('workflow.json', async () => {
     const {default: data} = await import('./fixtures/workflow.json')
     expect(
-      (await contentfulToDataset(data as any, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/react-starter/blob/2c40987790d22dcf9876d09cd621e82131371964/contentful/export.json
   test('react-starter.json', async () => {
     const {default: data} = await import('./fixtures/react-starter.json')
     expect(
-      (await contentfulToDataset(data as any, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/starter-gatsby-blog/blob/4dc30e2621adbc10177d1ccbee518c6fcee70a60/contentful/export.json
   test('gatsby-blog.json', async () => {
     const {default: data} = await import('./fixtures/gatsby-blog.json')
     expect(
-      (await contentfulToDataset(data as any, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/starter-hydrogen-store/blob/6bc733608fc1e8c961c0cca654eaf44636571cc5/contentful-export.json
   test('hydrogen-store.json', async () => {
     const {default: data} = await import('./fixtures/hydrogen-store.json')
     expect(
-      (await contentfulToDataset(data as any, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/starter-javascript-cookbook/blob/8c3655b1b1d29458d5a84da31e39753ab6ee8233/contentful/export.json
   test('cookbook.json', async () => {
     const {default: data} = await import('./fixtures/cookbook.json')
     expect(
-      (await contentfulToDataset(data as any, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/starter-remix-portfolio/blob/fce56f371bfce44ca69aeffa54428f6f9f589d98/remix.init/contentful/export.json
   test('remix.json', async () => {
     const {default: data} = await import('./fixtures/remix.json')
     expect(
-      (await contentfulToDataset(data as any, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/starters/blob/867272460e3d1e20daf5d856fa7411d96978ff83/examples/gatsby-blog/contentful/export.json
   test('gatsby-blog2.json', async () => {
     const {default: data} = await import('./fixtures/gatsby-blog2.json')
     expect(
-      (await contentfulToDataset(data as any, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/starters/blob/867272460e3d1e20daf5d856fa7411d96978ff83/examples/knowledge-base/contentful/export.json
   test('knowledge-base.json', async () => {
     const {default: data} = await import('./fixtures/knowledge-base.json')
     expect(
-      (await contentfulToDataset(data as any, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/starters/blob/867272460e3d1e20daf5d856fa7411d96978ff83/examples/next.js-blog/contentful/export.json
   test('nextjs.json', async () => {
     const {default: data} = await import('./fixtures/nextjs.json')
     expect(
-      (await contentfulToDataset(data as any, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
   })
   // https://github.com/contentful/sveltekit-starter/blob/4dc8afe9701a36e455f5545914633648bf630372/contentful/export.json
   test('sveltekit.json', async () => {
     const {default: data} = await import('./fixtures/sveltekit.json')
     expect(
-      (await contentfulToDataset(data as any, smOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, smOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, imOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, imOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, wkOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, wkOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, pathOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, pathOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
     expect(
-      (await contentfulToDataset(data as any, mdOptions)).split('\n').map(parse),
+      (await contentfulToDataset({published: data as any}, mdOptions)).split('\n').map(parse),
     ).toMatchSnapshot()
   })
 })

--- a/src/test/drafts.test.ts
+++ b/src/test/drafts.test.ts
@@ -1,0 +1,65 @@
+import {describe, expect, test} from 'vitest'
+
+import {contentfulToDataset} from '../helpers/contentfulToDataset'
+import {parse} from './helpers'
+
+describe('Drafts', async () => {
+  test('rune', async () => {
+    const {default: data} = await import('./fixtures/drafts.drafts.json')
+    for (const entity of data.entries) {
+      const isDraft = !entity.sys.publishedVersion
+      const isChanged =
+        !!entity.sys.publishedVersion && entity.sys.version >= entity.sys.publishedVersion + 2
+      const isPublished =
+        !!entity.sys.publishedVersion && entity.sys.version == entity.sys.publishedVersion + 1
+      const isArchived = !!entity.sys.archivedVersion
+      console.log(
+        'isDraft',
+        isDraft,
+        'isChanged',
+        isChanged,
+        'isPublished',
+        isPublished,
+        'isArchived',
+        isArchived,
+      )
+    }
+  })
+
+  test('adds drafts from additional export', async () => {
+    const {default: data} = await import('./fixtures/drafts.json')
+    const options = {
+      intlMode: 'single',
+      weakRefs: false,
+      intlIdStructure: 'delimiter',
+      keepMarkdown: false,
+      locale: undefined,
+    } as const
+
+    const ndjson = await contentfulToDataset(data as any, options)
+    const docs = ndjson.split('\n').map(parse)
+
+    // Published and draft
+    const publishedWithDraft = docs.find((doc) => doc._id === '5NCD8ztIrVWo7MMBf9f81D')
+    expect(publishedWithDraft).toBeDefined()
+    expect(publishedWithDraft).to.contain({
+      _type: 'post',
+    })
+    expect(docs.find((doc) => doc._id === 'drafts.5NCD8ztIrVWo7MMBf9f81D')).toBeDefined()
+
+    // Exists only as drafts
+    expect(docs.find((doc) => doc._id === 'drafts.6tQpUjsZ4RyaSzxqNd0Id3')).toBeDefined()
+    expect(docs.find((doc) => doc._id === 'drafts.9lDgwws6jtn8ow1CkWDmA')).toBeDefined()
+
+    // Published doc with a broken draft ref
+    const doc = docs.find((doc) => doc._id === '6T4f1JKI3KbeqElChsqUZs')
+    expect(doc).toBeDefined()
+    expect(doc).to.contain({
+      _type: 'post',
+      author: {
+        _type: 'reference',
+        _ref: '9lDgwws6jtn8ow1CkWDmA',
+      },
+    })
+  })
+})

--- a/src/test/drafts.test.ts
+++ b/src/test/drafts.test.ts
@@ -4,28 +4,6 @@ import {contentfulToDataset} from '../helpers/contentfulToDataset'
 import {parse} from './helpers'
 
 describe('Drafts', async () => {
-  test('rune', async () => {
-    const {default: data} = await import('./fixtures/drafts.drafts.json')
-    for (const entity of data.entries) {
-      const isDraft = !entity.sys.publishedVersion
-      const isChanged =
-        !!entity.sys.publishedVersion && entity.sys.version >= entity.sys.publishedVersion + 2
-      const isPublished =
-        !!entity.sys.publishedVersion && entity.sys.version == entity.sys.publishedVersion + 1
-      const isArchived = !!entity.sys.archivedVersion
-      console.log(
-        'isDraft',
-        isDraft,
-        'isChanged',
-        isChanged,
-        'isPublished',
-        isPublished,
-        'isArchived',
-        isArchived,
-      )
-    }
-  })
-
   test('adds drafts from additional export', async () => {
     const {default: data} = await import('./fixtures/drafts.json')
     const options = {
@@ -39,6 +17,10 @@ describe('Drafts', async () => {
     const ndjson = await contentfulToDataset(data as any, options)
     const docs = ndjson.split('\n').map(parse)
 
+    // Exists only as drafts
+    expect(docs.find((doc) => doc._id === 'drafts.6tQpUjsZ4RyaSzxqNd0Id3')).toBeDefined()
+    expect(docs.find((doc) => doc._id === 'drafts.9lDgwws6jtn8ow1CkWDmA')).toBeDefined()
+
     // Published and draft
     const publishedWithDraft = docs.find((doc) => doc._id === '5NCD8ztIrVWo7MMBf9f81D')
     expect(publishedWithDraft).toBeDefined()
@@ -46,10 +28,6 @@ describe('Drafts', async () => {
       _type: 'post',
     })
     expect(docs.find((doc) => doc._id === 'drafts.5NCD8ztIrVWo7MMBf9f81D')).toBeDefined()
-
-    // Exists only as drafts
-    expect(docs.find((doc) => doc._id === 'drafts.6tQpUjsZ4RyaSzxqNd0Id3')).toBeDefined()
-    expect(docs.find((doc) => doc._id === 'drafts.9lDgwws6jtn8ow1CkWDmA')).toBeDefined()
 
     // Published doc with a broken draft ref
     const doc = docs.find((doc) => doc._id === '6T4f1JKI3KbeqElChsqUZs')

--- a/src/test/drafts.test.ts
+++ b/src/test/drafts.test.ts
@@ -18,7 +18,7 @@ describe('Drafts', async () => {
     const ndjson = await contentfulToDataset(
       {
         drafts: drafts as any,
-        published: published as any
+        published: published as any,
       },
       options,
     )
@@ -41,10 +41,10 @@ describe('Drafts', async () => {
     expect(docs.find((doc) => doc._id === 'drafts.5NCD8ztIrVWo7MMBf9f81D')).toBeDefined()
 
     // Published doc with a broken draft ref
-    const doc = docs.find((doc) => doc._id === '6T4f1JKI3KbeqElChsqUZs')
+    const doc = docs.find((document) => document._id === '6T4f1JKI3KbeqElChsqUZs')
     expect(doc).toBeDefined()
     expect(doc.author).toBeNull()
   })
 
-  test("Draft doc with a draft reference")
+  test('Draft doc with a draft reference')
 })

--- a/src/test/drafts.test.ts
+++ b/src/test/drafts.test.ts
@@ -46,8 +46,17 @@ describe('Drafts', async () => {
         type: 'person',
         template: {
           id: 'person',
+          params: {},
         },
       },
     })
+  })
+  test('Published post with a broken ref to a draft', async ({docs}) => {
+    const post = docs.find((doc) => doc._id === '5675910SUMh7sD0qbhvdp2')
+    expect(post).toBeDefined()
+    expect(post?.author).toBeNull()
+
+    // Also this post should not have a draft
+    expect(docs.find((doc) => doc._id === 'draft.5675910SUMh7sD0qbhvdp2')).toBeUndefined()
   })
 })

--- a/src/test/drafts.test.ts
+++ b/src/test/drafts.test.ts
@@ -1,50 +1,53 @@
-import {describe, expect, test} from 'vitest'
+import {SanityDocument} from '@sanity/client'
+import {beforeEach, describe, expect, test} from 'vitest'
 
 import {contentfulToDataset} from '../helpers/contentfulToDataset'
 import {parse} from './helpers'
 
+declare module 'vitest' {
+  export interface TestContext {
+    docs: SanityDocument[]
+  }
+}
+
+beforeEach(async (context) => {
+  const {default: drafts} = await import('./fixtures/drafts.json')
+  const {default: published} = await import('./fixtures/drafts.published.json')
+  const options = {
+    intlMode: 'single',
+    weakRefs: false,
+    intlIdStructure: 'delimiter',
+    keepMarkdown: false,
+    locale: undefined,
+  } as const
+
+  const ndjson = await contentfulToDataset(
+    {
+      drafts: drafts as any,
+      published: published as any,
+    },
+    options,
+  )
+  context.docs = ndjson.split('\n').map(parse)
+})
+
 describe('Drafts', async () => {
-  test('adds drafts from additional export', async () => {
-    const {default: drafts} = await import('./fixtures/drafts.json')
-    const {default: published} = await import('./fixtures/drafts.published.json')
-    const options = {
-      intlMode: 'single',
-      weakRefs: false,
-      intlIdStructure: 'delimiter',
-      keepMarkdown: false,
-      locale: undefined,
-    } as const
+  test('Draft doc with a draft reference', async ({docs}) => {
+    const post = docs.find((doc) => doc._id === 'drafts.4RIfygf1stLd0J1gycYXlu')
+    expect(post).toBeDefined()
+    const person = docs.find((doc) => doc._id === 'drafts.6PRft3TsWQAf2Fkeb6ZKhb')
+    expect(person).toBeDefined()
 
-    const ndjson = await contentfulToDataset(
-      {
-        drafts: drafts as any,
-        published: published as any,
+    expect(post?.author).toEqual({
+      _ref: person?._id,
+      _type: 'reference',
+      _weak: true,
+      _strengthenOnPublish: {
+        type: 'person',
+        template: {
+          id: 'person',
+        },
       },
-      options,
-    )
-    const docs = ndjson.split('\n').map(parse)
-
-    // Check for duplicates in docs array based on _id
-    const ids = docs.map((doc) => doc._id)
-    expect(ids).toHaveLength(new Set(ids).size)
-
-    // Exists only as drafts
-    const draftIds = [`6tQpUjsZ4RyaSzxqNd0Id3`, `9lDgwws6jtn8ow1CkWDmA`]
-    for (const id of draftIds) {
-      expect(docs.find((doc) => doc._id === `drafts.${id}`)).toBeDefined()
-      // Should not be a published document
-      expect(docs.filter((doc) => doc._id === id)).toHaveLength(0)
-    }
-
-    // Published and draft
-    expect(docs.filter((doc) => doc._id === '5NCD8ztIrVWo7MMBf9f81D')).toHaveLength(1)
-    expect(docs.find((doc) => doc._id === 'drafts.5NCD8ztIrVWo7MMBf9f81D')).toBeDefined()
-
-    // Published doc with a broken draft ref
-    const doc = docs.find((document) => document._id === '6T4f1JKI3KbeqElChsqUZs')
-    expect(doc).toBeDefined()
-    expect(doc.author).toBeNull()
+    })
   })
-
-  test('Draft doc with a draft reference')
 })

--- a/src/test/fixtures/brokenRefs.published.json
+++ b/src/test/fixtures/brokenRefs.published.json
@@ -1,0 +1,895 @@
+{
+  "contentTypes": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "id": "person",
+        "type": "ContentType",
+        "createdAt": "2023-02-28T20:28:23.335Z",
+        "updatedAt": "2023-03-20T20:32:20.557Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 5,
+        "publishedAt": "2023-03-20T20:32:20.557Z",
+        "firstPublishedAt": "2023-02-28T20:28:23.585Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "publishedCounter": 3,
+        "version": 6,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        }
+      },
+      "displayField": "name",
+      "name": "Person",
+      "description": "A human being",
+      "fields": [
+        {
+          "id": "name",
+          "name": "name",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "profilePicture",
+          "name": "profilePicture",
+          "type": "Link",
+          "localized": false,
+          "required": true,
+          "validations": [
+            {
+              "assetFileSize": {
+                "min": null,
+                "max": 5242880
+              },
+              "message": "Profile photo too large, try again with a smaller file"
+            }
+          ],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Asset"
+        },
+        {
+          "id": "biography",
+          "name": "biography",
+          "type": "RichText",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "enabledMarks": ["bold", "italic", "underline"],
+              "message": "Only bold, italic, and underline marks are allowed"
+            },
+            {
+              "enabledNodeTypes": [
+                "unordered-list",
+                "ordered-list",
+                "blockquote",
+                "table",
+                "entry-hyperlink",
+                "hyperlink",
+                "embedded-entry-block",
+                "embedded-entry-inline",
+                "embedded-asset-block"
+              ],
+              "message": "Only unordered list, ordered list, quote, table, link to entry, link to Url, block entry, inline entry, and asset nodes are allowed"
+            },
+            {
+              "nodes": {}
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "friend",
+          "name": "friend",
+          "type": "Link",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Entry"
+        },
+        {
+          "id": "friends",
+          "name": "friends",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Link",
+            "validations": [],
+            "linkType": "Entry"
+          }
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "id": "post",
+        "type": "ContentType",
+        "createdAt": "2023-03-20T20:34:37.761Z",
+        "updatedAt": "2023-03-20T20:34:38.084Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 1,
+        "publishedAt": "2023-03-20T20:34:38.084Z",
+        "firstPublishedAt": "2023-03-20T20:34:38.084Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 2,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        }
+      },
+      "displayField": "title",
+      "name": "Post",
+      "description": "",
+      "fields": [
+        {
+          "id": "title",
+          "name": "title",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "author",
+          "name": "author",
+          "type": "Link",
+          "localized": false,
+          "required": false,
+          "validations": [],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Entry"
+        }
+      ]
+    }
+  ],
+  "tags": [],
+  "editorInterfaces": [
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "space": {
+          "sys": {
+            "id": "6cvippge3sd1",
+            "type": "Link",
+            "linkType": "Space"
+          }
+        },
+        "version": 6,
+        "createdAt": "2023-02-28T20:28:23.753Z",
+        "createdBy": {
+          "sys": {
+            "id": "2jYeCfa60UhCFs76N2hp6o",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "updatedAt": "2023-03-20T20:32:21.135Z",
+        "updatedBy": {
+          "sys": {
+            "id": "2jYeCfa60UhCFs76N2hp6o",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "id": "person",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        }
+      },
+      "editors": [
+        {
+          "widgetId": "default-editor",
+          "widgetNamespace": "editor-builtin"
+        },
+        {
+          "widgetId": "tags-editor",
+          "widgetNamespace": "editor-builtin"
+        },
+        {
+          "widgetId": "69mKkEFmMO9ue4lwWfto2C",
+          "widgetNamespace": "app"
+        }
+      ],
+      "sidebar": [
+        {
+          "widgetId": "publication-widget",
+          "widgetNamespace": "sidebar-builtin"
+        },
+        {
+          "widgetId": "content-preview-widget",
+          "widgetNamespace": "sidebar-builtin"
+        },
+        {
+          "widgetId": "66frtrAqmWSowDJzQNDiD",
+          "widgetNamespace": "app"
+        },
+        {
+          "widgetId": "703nAvCC2nuDjQCiI5P8e2",
+          "widgetNamespace": "app"
+        }
+      ],
+      "controls": [
+        {
+          "fieldId": "name",
+          "settings": {
+            "helpText": "Persons given, or preferred name"
+          },
+          "widgetId": "singleLine",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "profilePicture",
+          "widgetId": "assetLinkEditor",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "biography",
+          "widgetId": "richTextEditor",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "friend",
+          "widgetId": "entryLinkEditor",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "friends",
+          "widgetId": "entryLinksEditor",
+          "widgetNamespace": "builtin"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "space": {
+          "sys": {
+            "id": "6cvippge3sd1",
+            "type": "Link",
+            "linkType": "Space"
+          }
+        },
+        "version": 2,
+        "createdAt": "2023-03-20T20:34:38.187Z",
+        "createdBy": {
+          "sys": {
+            "id": "2jYeCfa60UhCFs76N2hp6o",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "updatedAt": "2023-03-20T20:34:38.722Z",
+        "updatedBy": {
+          "sys": {
+            "id": "2jYeCfa60UhCFs76N2hp6o",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "id": "post",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        }
+      },
+      "editors": [
+        {
+          "widgetId": "default-editor",
+          "widgetNamespace": "editor-builtin"
+        },
+        {
+          "widgetId": "tags-editor",
+          "widgetNamespace": "editor-builtin"
+        },
+        {
+          "widgetId": "69mKkEFmMO9ue4lwWfto2C",
+          "widgetNamespace": "app"
+        }
+      ],
+      "sidebar": [
+        {
+          "widgetId": "publication-widget",
+          "widgetNamespace": "sidebar-builtin"
+        },
+        {
+          "widgetId": "content-preview-widget",
+          "widgetNamespace": "sidebar-builtin"
+        },
+        {
+          "widgetId": "66frtrAqmWSowDJzQNDiD",
+          "widgetNamespace": "app"
+        },
+        {
+          "widgetId": "703nAvCC2nuDjQCiI5P8e2",
+          "widgetNamespace": "app"
+        }
+      ],
+      "controls": [
+        {
+          "fieldId": "title",
+          "widgetId": "singleLine",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "author",
+          "widgetId": "entryLinkEditor",
+          "widgetNamespace": "builtin"
+        }
+      ]
+    }
+  ],
+  "entries": [
+    {
+      "metadata": {
+        "tags": []
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "id": "mz5wbHAhuHQUYQV16wRP6",
+        "type": "Entry",
+        "createdAt": "2023-02-28T20:28:30.271Z",
+        "updatedAt": "2023-02-28T20:30:40.068Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 7,
+        "publishedAt": "2023-02-28T20:30:40.068Z",
+        "firstPublishedAt": "2023-02-28T20:30:40.068Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 8,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "automationTags": [],
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "person"
+          }
+        }
+      },
+      "fields": {
+        "name": {
+          "en-US": "Rune Botten"
+        },
+        "profilePicture": {
+          "en-US": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Asset",
+              "id": "4S9vZQAr0k7gS37zi7iNDG"
+            }
+          }
+        },
+        "biography": {
+          "en-US": {
+            "nodeType": "document",
+            "data": {},
+            "content": [
+              {
+                "nodeType": "paragraph",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "Rune ",
+                    "marks": [],
+                    "data": {}
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": "is",
+                    "marks": [
+                      {
+                        "type": "bold"
+                      }
+                    ],
+                    "data": {}
+                  },
+                  {
+                    "nodeType": "text",
+                    "value": " testing Contentful.",
+                    "marks": [],
+                    "data": {}
+                  }
+                ]
+              },
+              {
+                "nodeType": "paragraph",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "Infinite loop:",
+                    "marks": [],
+                    "data": {}
+                  }
+                ]
+              },
+              {
+                "nodeType": "embedded-entry-block",
+                "data": {
+                  "target": {
+                    "sys": {
+                      "id": "mz5wbHAhuHQUYQV16wRP6",
+                      "type": "Link",
+                      "linkType": "Entry"
+                    }
+                  }
+                },
+                "content": []
+              },
+              {
+                "nodeType": "paragraph",
+                "data": {},
+                "content": [
+                  {
+                    "nodeType": "text",
+                    "value": "",
+                    "marks": [],
+                    "data": {}
+                  }
+                ]
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "metadata": {
+        "tags": []
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "id": "1hkGvLGL9xU7H61aRGR95x",
+        "type": "Entry",
+        "createdAt": "2023-03-20T20:34:51.153Z",
+        "updatedAt": "2023-03-20T20:35:43.101Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 4,
+        "publishedAt": "2023-03-20T20:35:43.101Z",
+        "firstPublishedAt": "2023-03-20T20:35:43.101Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 5,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "automationTags": [],
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "post"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "My post"
+        },
+        "author": {
+          "en-US": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Entry",
+              "id": "mz5wbHAhuHQUYQV16wRP6"
+            }
+          }
+        }
+      }
+    },
+    {
+      "metadata": {
+        "tags": []
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "id": "1fJ8GxpEPc56k73EbxOj4p",
+        "type": "Entry",
+        "createdAt": "2023-03-21T16:38:15.297Z",
+        "updatedAt": "2023-03-21T16:38:34.504Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 2,
+        "publishedAt": "2023-03-21T16:38:22.962Z",
+        "firstPublishedAt": "2023-03-21T16:38:22.962Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 4,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "automationTags": [],
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "post"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "My published post with a draft on top"
+        }
+      }
+    },
+    {
+      "metadata": {
+        "tags": []
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "id": "1ulybB3BSdHCNQe2UCWbX5",
+        "type": "Entry",
+        "createdAt": "2023-03-21T17:22:59.405Z",
+        "updatedAt": "2023-03-21T17:23:36.587Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 3,
+        "publishedAt": "2023-03-21T17:23:36.587Z",
+        "firstPublishedAt": "2023-03-21T17:23:36.587Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 4,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "automationTags": [],
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "post"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Post with broken author link"
+        },
+        "author": {
+          "en-US": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Entry",
+              "id": "2TcV4M7TJFuxMIsEPUDIni"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "assets": [
+    {
+      "metadata": {
+        "tags": []
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "id": "4S9vZQAr0k7gS37zi7iNDG",
+        "type": "Asset",
+        "createdAt": "2023-02-28T20:29:09.498Z",
+        "updatedAt": "2023-02-28T20:32:04.972Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 5,
+        "publishedAt": "2023-02-28T20:32:04.972Z",
+        "firstPublishedAt": "2023-02-28T20:32:04.972Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 6,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Norway"
+        },
+        "description": {
+          "en-US": "A fjord in Norway"
+        },
+        "file": {
+          "en-US": {
+            "url": "//images.ctfassets.net/6cvippge3sd1/4S9vZQAr0k7gS37zi7iNDG/c3c715c652fd3a26f94a032e1a06cf9a/image.png",
+            "details": {
+              "size": 1311262,
+              "image": {
+                "width": 1109,
+                "height": 750
+              }
+            },
+            "fileName": "image.png",
+            "contentType": "image/png"
+          }
+        }
+      }
+    }
+  ],
+  "locales": [
+    {
+      "name": "English (United States)",
+      "code": "en-US",
+      "fallbackCode": null,
+      "default": true,
+      "contentManagementApi": true,
+      "contentDeliveryApi": true,
+      "optional": false,
+      "sys": {
+        "type": "Locale",
+        "id": "2nEMtGrzor8718dMRdtm5D",
+        "version": 1,
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "environment": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Environment",
+            "id": "master",
+            "uuid": "f338763c-b95e-483e-bebb-ca6351c96fff"
+          }
+        },
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "createdAt": "2023-02-23T20:12:22Z",
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "updatedAt": "2023-02-23T20:12:22Z"
+      }
+    }
+  ]
+}

--- a/src/test/fixtures/drafts.json
+++ b/src/test/fixtures/drafts.json
@@ -161,7 +161,7 @@
         "id": "post",
         "type": "ContentType",
         "createdAt": "2023-03-20T20:34:37.761Z",
-        "updatedAt": "2023-03-22T00:03:47.790Z",
+        "updatedAt": "2023-03-23T00:27:59.264Z",
         "environment": {
           "sys": {
             "id": "master",
@@ -169,8 +169,8 @@
             "linkType": "Environment"
           }
         },
-        "publishedVersion": 13,
-        "publishedAt": "2023-03-22T00:03:47.790Z",
+        "publishedVersion": 15,
+        "publishedAt": "2023-03-23T00:27:59.264Z",
         "firstPublishedAt": "2023-03-20T20:34:38.084Z",
         "createdBy": {
           "sys": {
@@ -186,8 +186,8 @@
             "id": "2jYeCfa60UhCFs76N2hp6o"
           }
         },
-        "publishedCounter": 7,
-        "version": 14,
+        "publishedCounter": 8,
+        "version": 16,
         "publishedBy": {
           "sys": {
             "type": "Link",
@@ -222,6 +222,54 @@
           "disabled": false,
           "omitted": false,
           "linkType": "Entry"
+        },
+        {
+          "id": "body",
+          "name": "body",
+          "type": "RichText",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "enabledMarks": [
+                "bold",
+                "italic",
+                "underline",
+                "code",
+                "superscript",
+                "subscript"
+              ],
+              "message": "Only bold, italic, underline, code, superscript, and subscript marks are allowed"
+            },
+            {
+              "enabledNodeTypes": [
+                "heading-1",
+                "heading-2",
+                "heading-3",
+                "heading-4",
+                "heading-5",
+                "heading-6",
+                "ordered-list",
+                "unordered-list",
+                "hr",
+                "blockquote",
+                "embedded-entry-block",
+                "embedded-asset-block",
+                "table",
+                "entry-hyperlink",
+                "asset-hyperlink",
+                "embedded-entry-inline",
+                "hyperlink"
+              ],
+              "message": "Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, block entry, asset, table, link to entry, link to asset, inline entry, and link to Url nodes are allowed"
+            },
+            {
+              "nodes": {
+              }
+            }
+          ],
+          "disabled": false,
+          "omitted": false
         }
       ]
     }
@@ -346,7 +394,7 @@
             "linkType": "Space"
           }
         },
-        "version": 14,
+        "version": 16,
         "createdAt": "2023-03-20T20:34:38.187Z",
         "createdBy": {
           "sys": {
@@ -355,7 +403,7 @@
             "linkType": "User"
           }
         },
-        "updatedAt": "2023-03-22T00:03:48.358Z",
+        "updatedAt": "2023-03-23T00:28:00.355Z",
         "updatedBy": {
           "sys": {
             "id": "2jYeCfa60UhCFs76N2hp6o",
@@ -420,6 +468,11 @@
           "fieldId": "author",
           "widgetId": "entryLinkEditor",
           "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "body",
+          "widgetId": "richTextEditor",
+          "widgetNamespace": "builtin"
         }
       ]
     }
@@ -438,76 +491,10 @@
             "id": "6cvippge3sd1"
           }
         },
-        "id": "5NCD8ztIrVWo7MMBf9f81D",
+        "id": "4RIfygf1stLd0J1gycYXlu",
         "type": "Entry",
-        "createdAt": "2023-03-21T23:43:37.728Z",
-        "updatedAt": "2023-03-21T23:43:53.315Z",
-        "environment": {
-          "sys": {
-            "id": "master",
-            "type": "Link",
-            "linkType": "Environment"
-          }
-        },
-        "publishedVersion": 2,
-        "publishedAt": "2023-03-21T23:43:44.399Z",
-        "firstPublishedAt": "2023-03-21T23:43:44.399Z",
-        "createdBy": {
-          "sys": {
-            "type": "Link",
-            "linkType": "User",
-            "id": "2jYeCfa60UhCFs76N2hp6o"
-          }
-        },
-        "updatedBy": {
-          "sys": {
-            "type": "Link",
-            "linkType": "User",
-            "id": "2jYeCfa60UhCFs76N2hp6o"
-          }
-        },
-        "publishedCounter": 1,
-        "version": 4,
-        "publishedBy": {
-          "sys": {
-            "type": "Link",
-            "linkType": "User",
-            "id": "2jYeCfa60UhCFs76N2hp6o"
-          }
-        },
-        "automationTags": [
-        ],
-        "contentType": {
-          "sys": {
-            "type": "Link",
-            "linkType": "ContentType",
-            "id": "post"
-          }
-        }
-      },
-      "fields": {
-        "title": {
-          "en-US": "Draft version of published page"
-        }
-      }
-    },
-    {
-      "metadata": {
-        "tags": [
-        ]
-      },
-      "sys": {
-        "space": {
-          "sys": {
-            "type": "Link",
-            "linkType": "Space",
-            "id": "6cvippge3sd1"
-          }
-        },
-        "id": "4Avyvms39CuJs6TS5E2e1J",
-        "type": "Entry",
-        "createdAt": "2023-03-21T23:44:02.374Z",
-        "updatedAt": "2023-03-21T23:44:15.568Z",
+        "createdAt": "2023-03-24T20:35:35.264Z",
+        "updatedAt": "2023-03-24T20:36:28.219Z",
         "environment": {
           "sys": {
             "id": "master",
@@ -530,7 +517,7 @@
           }
         },
         "publishedCounter": 0,
-        "version": 3,
+        "version": 6,
         "automationTags": [
         ],
         "contentType": {
@@ -543,14 +530,14 @@
       },
       "fields": {
         "title": {
-          "en-US": "Draft page with draft ref"
+          "en-US": "Draft page"
         },
         "author": {
           "en-US": {
             "sys": {
               "type": "Link",
               "linkType": "Entry",
-              "id": "6tQpUjsZ4RyaSzxqNd0Id3"
+              "id": "6PRft3TsWQAf2Fkeb6ZKhb"
             }
           }
         }
@@ -569,10 +556,10 @@
             "id": "6cvippge3sd1"
           }
         },
-        "id": "6tQpUjsZ4RyaSzxqNd0Id3",
+        "id": "6PRft3TsWQAf2Fkeb6ZKhb",
         "type": "Entry",
-        "createdAt": "2023-03-21T23:44:10.228Z",
-        "updatedAt": "2023-03-21T23:44:17.167Z",
+        "createdAt": "2023-03-24T20:36:22.675Z",
+        "updatedAt": "2023-03-24T20:36:28.180Z",
         "environment": {
           "sys": {
             "id": "master",
@@ -608,138 +595,7 @@
       },
       "fields": {
         "name": {
-          "en-US": "Draft Person"
-        }
-      }
-    },
-    {
-      "metadata": {
-        "tags": [
-        ]
-      },
-      "sys": {
-        "space": {
-          "sys": {
-            "type": "Link",
-            "linkType": "Space",
-            "id": "6cvippge3sd1"
-          }
-        },
-        "id": "6T4f1JKI3KbeqElChsqUZs",
-        "type": "Entry",
-        "createdAt": "2023-03-21T23:44:26.925Z",
-        "updatedAt": "2023-03-21T23:45:03.006Z",
-        "environment": {
-          "sys": {
-            "id": "master",
-            "type": "Link",
-            "linkType": "Environment"
-          }
-        },
-        "publishedVersion": 3,
-        "publishedAt": "2023-03-21T23:45:03.006Z",
-        "firstPublishedAt": "2023-03-21T23:45:03.006Z",
-        "createdBy": {
-          "sys": {
-            "type": "Link",
-            "linkType": "User",
-            "id": "2jYeCfa60UhCFs76N2hp6o"
-          }
-        },
-        "updatedBy": {
-          "sys": {
-            "type": "Link",
-            "linkType": "User",
-            "id": "2jYeCfa60UhCFs76N2hp6o"
-          }
-        },
-        "publishedCounter": 1,
-        "version": 4,
-        "publishedBy": {
-          "sys": {
-            "type": "Link",
-            "linkType": "User",
-            "id": "2jYeCfa60UhCFs76N2hp6o"
-          }
-        },
-        "automationTags": [
-        ],
-        "contentType": {
-          "sys": {
-            "type": "Link",
-            "linkType": "ContentType",
-            "id": "post"
-          }
-        }
-      },
-      "fields": {
-        "title": {
-          "en-US": "Published page with draft person"
-        },
-        "author": {
-          "en-US": {
-            "sys": {
-              "type": "Link",
-              "linkType": "Entry",
-              "id": "9lDgwws6jtn8ow1CkWDmA"
-            }
-          }
-        }
-      }
-    },
-    {
-      "metadata": {
-        "tags": [
-        ]
-      },
-      "sys": {
-        "space": {
-          "sys": {
-            "type": "Link",
-            "linkType": "Space",
-            "id": "6cvippge3sd1"
-          }
-        },
-        "id": "9lDgwws6jtn8ow1CkWDmA",
-        "type": "Entry",
-        "createdAt": "2023-03-21T23:44:49.357Z",
-        "updatedAt": "2023-03-21T23:44:56.419Z",
-        "environment": {
-          "sys": {
-            "id": "master",
-            "type": "Link",
-            "linkType": "Environment"
-          }
-        },
-        "createdBy": {
-          "sys": {
-            "type": "Link",
-            "linkType": "User",
-            "id": "2jYeCfa60UhCFs76N2hp6o"
-          }
-        },
-        "updatedBy": {
-          "sys": {
-            "type": "Link",
-            "linkType": "User",
-            "id": "2jYeCfa60UhCFs76N2hp6o"
-          }
-        },
-        "publishedCounter": 0,
-        "version": 2,
-        "automationTags": [
-        ],
-        "contentType": {
-          "sys": {
-            "type": "Link",
-            "linkType": "ContentType",
-            "id": "person"
-          }
-        }
-      },
-      "fields": {
-        "name": {
-          "en-US": "Another draft person, never published"
+          "en-US": "Draft person"
         }
       }
     }

--- a/src/test/fixtures/drafts.json
+++ b/src/test/fixtures/drafts.json
@@ -598,6 +598,81 @@
           "en-US": "Draft person"
         }
       }
+    },
+    {
+      "metadata": {
+        "tags": [
+        ]
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "id": "5675910SUMh7sD0qbhvdp2",
+        "type": "Entry",
+        "createdAt": "2023-03-24T20:56:11.973Z",
+        "updatedAt": "2023-03-24T20:56:54.930Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 5,
+        "publishedAt": "2023-03-24T20:56:54.930Z",
+        "firstPublishedAt": "2023-03-24T20:56:54.930Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 6,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "automationTags": [
+        ],
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "post"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Published post with broken ref to a draft"
+        },
+        "author": {
+          "en-US": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Entry",
+              "id": "6PRft3TsWQAf2Fkeb6ZKhb"
+            }
+          }
+        }
+      }
     }
   ],
   "assets": [

--- a/src/test/fixtures/drafts.json
+++ b/src/test/fixtures/drafts.json
@@ -1,0 +1,870 @@
+{
+  "contentTypes": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "id": "person",
+        "type": "ContentType",
+        "createdAt": "2023-02-28T20:28:23.335Z",
+        "updatedAt": "2023-03-20T20:32:20.557Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 5,
+        "publishedAt": "2023-03-20T20:32:20.557Z",
+        "firstPublishedAt": "2023-02-28T20:28:23.585Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "publishedCounter": 3,
+        "version": 6,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        }
+      },
+      "displayField": "name",
+      "name": "Person",
+      "description": "A human being",
+      "fields": [
+        {
+          "id": "name",
+          "name": "name",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "profilePicture",
+          "name": "profilePicture",
+          "type": "Link",
+          "localized": false,
+          "required": true,
+          "validations": [
+            {
+              "assetFileSize": {
+                "min": null,
+                "max": 5242880
+              },
+              "message": "Profile photo too large, try again with a smaller file"
+            }
+          ],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Asset"
+        },
+        {
+          "id": "biography",
+          "name": "biography",
+          "type": "RichText",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "enabledMarks": [
+                "bold",
+                "italic",
+                "underline"
+              ],
+              "message": "Only bold, italic, and underline marks are allowed"
+            },
+            {
+              "enabledNodeTypes": [
+                "unordered-list",
+                "ordered-list",
+                "blockquote",
+                "table",
+                "entry-hyperlink",
+                "hyperlink",
+                "embedded-entry-block",
+                "embedded-entry-inline",
+                "embedded-asset-block"
+              ],
+              "message": "Only unordered list, ordered list, quote, table, link to entry, link to Url, block entry, inline entry, and asset nodes are allowed"
+            },
+            {
+              "nodes": {
+              }
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "friend",
+          "name": "friend",
+          "type": "Link",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Entry"
+        },
+        {
+          "id": "friends",
+          "name": "friends",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Link",
+            "validations": [
+            ],
+            "linkType": "Entry"
+          }
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "id": "post",
+        "type": "ContentType",
+        "createdAt": "2023-03-20T20:34:37.761Z",
+        "updatedAt": "2023-03-22T00:03:47.790Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 13,
+        "publishedAt": "2023-03-22T00:03:47.790Z",
+        "firstPublishedAt": "2023-03-20T20:34:38.084Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "publishedCounter": 7,
+        "version": 14,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        }
+      },
+      "displayField": "title",
+      "name": "Post",
+      "description": "",
+      "fields": [
+        {
+          "id": "title",
+          "name": "title",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "author",
+          "name": "author",
+          "type": "Link",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Entry"
+        }
+      ]
+    }
+  ],
+  "tags": [
+  ],
+  "editorInterfaces": [
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "space": {
+          "sys": {
+            "id": "6cvippge3sd1",
+            "type": "Link",
+            "linkType": "Space"
+          }
+        },
+        "version": 6,
+        "createdAt": "2023-02-28T20:28:23.753Z",
+        "createdBy": {
+          "sys": {
+            "id": "2jYeCfa60UhCFs76N2hp6o",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "updatedAt": "2023-03-20T20:32:21.135Z",
+        "updatedBy": {
+          "sys": {
+            "id": "2jYeCfa60UhCFs76N2hp6o",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "id": "person",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        }
+      },
+      "editors": [
+        {
+          "widgetId": "default-editor",
+          "widgetNamespace": "editor-builtin"
+        },
+        {
+          "widgetId": "tags-editor",
+          "widgetNamespace": "editor-builtin"
+        },
+        {
+          "widgetId": "69mKkEFmMO9ue4lwWfto2C",
+          "widgetNamespace": "app"
+        }
+      ],
+      "sidebar": [
+        {
+          "widgetId": "publication-widget",
+          "widgetNamespace": "sidebar-builtin"
+        },
+        {
+          "widgetId": "content-preview-widget",
+          "widgetNamespace": "sidebar-builtin"
+        },
+        {
+          "widgetId": "66frtrAqmWSowDJzQNDiD",
+          "widgetNamespace": "app"
+        },
+        {
+          "widgetId": "703nAvCC2nuDjQCiI5P8e2",
+          "widgetNamespace": "app"
+        }
+      ],
+      "controls": [
+        {
+          "fieldId": "name",
+          "settings": {
+            "helpText": "Persons given, or preferred name"
+          },
+          "widgetId": "singleLine",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "profilePicture",
+          "widgetId": "assetLinkEditor",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "biography",
+          "widgetId": "richTextEditor",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "friend",
+          "widgetId": "entryLinkEditor",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "friends",
+          "widgetId": "entryLinksEditor",
+          "widgetNamespace": "builtin"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "space": {
+          "sys": {
+            "id": "6cvippge3sd1",
+            "type": "Link",
+            "linkType": "Space"
+          }
+        },
+        "version": 14,
+        "createdAt": "2023-03-20T20:34:38.187Z",
+        "createdBy": {
+          "sys": {
+            "id": "2jYeCfa60UhCFs76N2hp6o",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "updatedAt": "2023-03-22T00:03:48.358Z",
+        "updatedBy": {
+          "sys": {
+            "id": "2jYeCfa60UhCFs76N2hp6o",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "id": "post",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        }
+      },
+      "editors": [
+        {
+          "widgetId": "default-editor",
+          "widgetNamespace": "editor-builtin"
+        },
+        {
+          "widgetId": "tags-editor",
+          "widgetNamespace": "editor-builtin"
+        },
+        {
+          "widgetId": "69mKkEFmMO9ue4lwWfto2C",
+          "widgetNamespace": "app"
+        }
+      ],
+      "sidebar": [
+        {
+          "widgetId": "publication-widget",
+          "widgetNamespace": "sidebar-builtin"
+        },
+        {
+          "widgetId": "content-preview-widget",
+          "widgetNamespace": "sidebar-builtin"
+        },
+        {
+          "widgetId": "66frtrAqmWSowDJzQNDiD",
+          "widgetNamespace": "app"
+        },
+        {
+          "widgetId": "703nAvCC2nuDjQCiI5P8e2",
+          "widgetNamespace": "app"
+        }
+      ],
+      "controls": [
+        {
+          "fieldId": "title",
+          "widgetId": "singleLine",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "author",
+          "widgetId": "entryLinkEditor",
+          "widgetNamespace": "builtin"
+        }
+      ]
+    }
+  ],
+  "entries": [
+    {
+      "metadata": {
+        "tags": [
+        ]
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "id": "5NCD8ztIrVWo7MMBf9f81D",
+        "type": "Entry",
+        "createdAt": "2023-03-21T23:43:37.728Z",
+        "updatedAt": "2023-03-21T23:43:53.315Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 2,
+        "publishedAt": "2023-03-21T23:43:44.399Z",
+        "firstPublishedAt": "2023-03-21T23:43:44.399Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 4,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "automationTags": [
+        ],
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "post"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Draft version of published page"
+        }
+      }
+    },
+    {
+      "metadata": {
+        "tags": [
+        ]
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "id": "4Avyvms39CuJs6TS5E2e1J",
+        "type": "Entry",
+        "createdAt": "2023-03-21T23:44:02.374Z",
+        "updatedAt": "2023-03-21T23:44:15.568Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "publishedCounter": 0,
+        "version": 3,
+        "automationTags": [
+        ],
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "post"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Draft page with draft ref"
+        },
+        "author": {
+          "en-US": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Entry",
+              "id": "6tQpUjsZ4RyaSzxqNd0Id3"
+            }
+          }
+        }
+      }
+    },
+    {
+      "metadata": {
+        "tags": [
+        ]
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "id": "6tQpUjsZ4RyaSzxqNd0Id3",
+        "type": "Entry",
+        "createdAt": "2023-03-21T23:44:10.228Z",
+        "updatedAt": "2023-03-21T23:44:17.167Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "publishedCounter": 0,
+        "version": 2,
+        "automationTags": [
+        ],
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "person"
+          }
+        }
+      },
+      "fields": {
+        "name": {
+          "en-US": "Draft Person"
+        }
+      }
+    },
+    {
+      "metadata": {
+        "tags": [
+        ]
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "id": "6T4f1JKI3KbeqElChsqUZs",
+        "type": "Entry",
+        "createdAt": "2023-03-21T23:44:26.925Z",
+        "updatedAt": "2023-03-21T23:45:03.006Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 3,
+        "publishedAt": "2023-03-21T23:45:03.006Z",
+        "firstPublishedAt": "2023-03-21T23:45:03.006Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 4,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "automationTags": [
+        ],
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "post"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Published page with draft person"
+        },
+        "author": {
+          "en-US": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Entry",
+              "id": "9lDgwws6jtn8ow1CkWDmA"
+            }
+          }
+        }
+      }
+    },
+    {
+      "metadata": {
+        "tags": [
+        ]
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "id": "9lDgwws6jtn8ow1CkWDmA",
+        "type": "Entry",
+        "createdAt": "2023-03-21T23:44:49.357Z",
+        "updatedAt": "2023-03-21T23:44:56.419Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "publishedCounter": 0,
+        "version": 2,
+        "automationTags": [
+        ],
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "person"
+          }
+        }
+      },
+      "fields": {
+        "name": {
+          "en-US": "Another draft person, never published"
+        }
+      }
+    }
+  ],
+  "assets": [
+    {
+      "metadata": {
+        "tags": [
+        ]
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "id": "4S9vZQAr0k7gS37zi7iNDG",
+        "type": "Asset",
+        "createdAt": "2023-02-28T20:29:09.498Z",
+        "updatedAt": "2023-02-28T20:32:04.972Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 5,
+        "publishedAt": "2023-02-28T20:32:04.972Z",
+        "firstPublishedAt": "2023-02-28T20:32:04.972Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "publishedCounter": 1,
+        "version": 6,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Norway"
+        },
+        "description": {
+          "en-US": "A fjord in Norway"
+        },
+        "file": {
+          "en-US": {
+            "url": "//images.ctfassets.net/6cvippge3sd1/4S9vZQAr0k7gS37zi7iNDG/c3c715c652fd3a26f94a032e1a06cf9a/image.png",
+            "details": {
+              "size": 1311262,
+              "image": {
+                "width": 1109,
+                "height": 750
+              }
+            },
+            "fileName": "image.png",
+            "contentType": "image/png"
+          }
+        }
+      }
+    }
+  ],
+  "locales": [
+    {
+      "name": "English (United States)",
+      "code": "en-US",
+      "fallbackCode": null,
+      "default": true,
+      "contentManagementApi": true,
+      "contentDeliveryApi": true,
+      "optional": false,
+      "sys": {
+        "type": "Locale",
+        "id": "2nEMtGrzor8718dMRdtm5D",
+        "version": 1,
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "environment": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Environment",
+            "id": "master",
+            "uuid": "f338763c-b95e-483e-bebb-ca6351c96fff"
+          }
+        },
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "createdAt": "2023-02-23T20:12:22Z",
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "updatedAt": "2023-02-23T20:12:22Z"
+      }
+    }
+  ]
+}

--- a/src/test/fixtures/drafts.published.json
+++ b/src/test/fixtures/drafts.published.json
@@ -478,6 +478,54 @@
     }
   ],
   "entries": [
+    {
+      "metadata": {
+        "tags": [
+        ]
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "id": "5675910SUMh7sD0qbhvdp2",
+        "type": "Entry",
+        "createdAt": "2023-03-24T20:56:54.930Z",
+        "updatedAt": "2023-03-24T20:56:54.930Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "post"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Published post with broken ref to a draft"
+        },
+        "author": {
+          "en-US": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Entry",
+              "id": "6PRft3TsWQAf2Fkeb6ZKhb"
+            }
+          }
+        }
+      }
+    }
   ],
   "assets": [
     {

--- a/src/test/fixtures/drafts.published.json
+++ b/src/test/fixtures/drafts.published.json
@@ -1,0 +1,614 @@
+{
+  "contentTypes": [
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "id": "person",
+        "type": "ContentType",
+        "createdAt": "2023-02-28T20:28:23.335Z",
+        "updatedAt": "2023-03-20T20:32:20.557Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 5,
+        "publishedAt": "2023-03-20T20:32:20.557Z",
+        "firstPublishedAt": "2023-02-28T20:28:23.585Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "publishedCounter": 3,
+        "version": 6,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        }
+      },
+      "displayField": "name",
+      "name": "Person",
+      "description": "A human being",
+      "fields": [
+        {
+          "id": "name",
+          "name": "name",
+          "type": "Symbol",
+          "localized": false,
+          "required": true,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "profilePicture",
+          "name": "profilePicture",
+          "type": "Link",
+          "localized": false,
+          "required": true,
+          "validations": [
+            {
+              "assetFileSize": {
+                "min": null,
+                "max": 5242880
+              },
+              "message": "Profile photo too large, try again with a smaller file"
+            }
+          ],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Asset"
+        },
+        {
+          "id": "biography",
+          "name": "biography",
+          "type": "RichText",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "enabledMarks": [
+                "bold",
+                "italic",
+                "underline"
+              ],
+              "message": "Only bold, italic, and underline marks are allowed"
+            },
+            {
+              "enabledNodeTypes": [
+                "unordered-list",
+                "ordered-list",
+                "blockquote",
+                "table",
+                "entry-hyperlink",
+                "hyperlink",
+                "embedded-entry-block",
+                "embedded-entry-inline",
+                "embedded-asset-block"
+              ],
+              "message": "Only unordered list, ordered list, quote, table, link to entry, link to Url, block entry, inline entry, and asset nodes are allowed"
+            },
+            {
+              "nodes": {
+              }
+            }
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "friend",
+          "name": "friend",
+          "type": "Link",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Entry"
+        },
+        {
+          "id": "friends",
+          "name": "friends",
+          "type": "Array",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false,
+          "items": {
+            "type": "Link",
+            "validations": [
+            ],
+            "linkType": "Entry"
+          }
+        }
+      ]
+    },
+    {
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "id": "post",
+        "type": "ContentType",
+        "createdAt": "2023-03-20T20:34:37.761Z",
+        "updatedAt": "2023-03-22T00:03:47.790Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "publishedVersion": 13,
+        "publishedAt": "2023-03-22T00:03:47.790Z",
+        "firstPublishedAt": "2023-03-20T20:34:38.084Z",
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "publishedCounter": 7,
+        "version": 14,
+        "publishedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        }
+      },
+      "displayField": "title",
+      "name": "Post",
+      "description": "",
+      "fields": [
+        {
+          "id": "title",
+          "name": "title",
+          "type": "Symbol",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false
+        },
+        {
+          "id": "author",
+          "name": "author",
+          "type": "Link",
+          "localized": false,
+          "required": false,
+          "validations": [
+          ],
+          "disabled": false,
+          "omitted": false,
+          "linkType": "Entry"
+        }
+      ]
+    }
+  ],
+  "tags": [
+  ],
+  "editorInterfaces": [
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "space": {
+          "sys": {
+            "id": "6cvippge3sd1",
+            "type": "Link",
+            "linkType": "Space"
+          }
+        },
+        "version": 6,
+        "createdAt": "2023-02-28T20:28:23.753Z",
+        "createdBy": {
+          "sys": {
+            "id": "2jYeCfa60UhCFs76N2hp6o",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "updatedAt": "2023-03-20T20:32:21.135Z",
+        "updatedBy": {
+          "sys": {
+            "id": "2jYeCfa60UhCFs76N2hp6o",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "id": "person",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        }
+      },
+      "editors": [
+        {
+          "widgetId": "default-editor",
+          "widgetNamespace": "editor-builtin"
+        },
+        {
+          "widgetId": "tags-editor",
+          "widgetNamespace": "editor-builtin"
+        },
+        {
+          "widgetId": "69mKkEFmMO9ue4lwWfto2C",
+          "widgetNamespace": "app"
+        }
+      ],
+      "sidebar": [
+        {
+          "widgetId": "publication-widget",
+          "widgetNamespace": "sidebar-builtin"
+        },
+        {
+          "widgetId": "content-preview-widget",
+          "widgetNamespace": "sidebar-builtin"
+        },
+        {
+          "widgetId": "66frtrAqmWSowDJzQNDiD",
+          "widgetNamespace": "app"
+        },
+        {
+          "widgetId": "703nAvCC2nuDjQCiI5P8e2",
+          "widgetNamespace": "app"
+        }
+      ],
+      "controls": [
+        {
+          "fieldId": "name",
+          "settings": {
+            "helpText": "Persons given, or preferred name"
+          },
+          "widgetId": "singleLine",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "profilePicture",
+          "widgetId": "assetLinkEditor",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "biography",
+          "widgetId": "richTextEditor",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "friend",
+          "widgetId": "entryLinkEditor",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "friends",
+          "widgetId": "entryLinksEditor",
+          "widgetNamespace": "builtin"
+        }
+      ]
+    },
+    {
+      "sys": {
+        "id": "default",
+        "type": "EditorInterface",
+        "space": {
+          "sys": {
+            "id": "6cvippge3sd1",
+            "type": "Link",
+            "linkType": "Space"
+          }
+        },
+        "version": 14,
+        "createdAt": "2023-03-20T20:34:38.187Z",
+        "createdBy": {
+          "sys": {
+            "id": "2jYeCfa60UhCFs76N2hp6o",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "updatedAt": "2023-03-22T00:03:48.358Z",
+        "updatedBy": {
+          "sys": {
+            "id": "2jYeCfa60UhCFs76N2hp6o",
+            "type": "Link",
+            "linkType": "User"
+          }
+        },
+        "contentType": {
+          "sys": {
+            "id": "post",
+            "type": "Link",
+            "linkType": "ContentType"
+          }
+        },
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        }
+      },
+      "editors": [
+        {
+          "widgetId": "default-editor",
+          "widgetNamespace": "editor-builtin"
+        },
+        {
+          "widgetId": "tags-editor",
+          "widgetNamespace": "editor-builtin"
+        },
+        {
+          "widgetId": "69mKkEFmMO9ue4lwWfto2C",
+          "widgetNamespace": "app"
+        }
+      ],
+      "sidebar": [
+        {
+          "widgetId": "publication-widget",
+          "widgetNamespace": "sidebar-builtin"
+        },
+        {
+          "widgetId": "content-preview-widget",
+          "widgetNamespace": "sidebar-builtin"
+        },
+        {
+          "widgetId": "66frtrAqmWSowDJzQNDiD",
+          "widgetNamespace": "app"
+        },
+        {
+          "widgetId": "703nAvCC2nuDjQCiI5P8e2",
+          "widgetNamespace": "app"
+        }
+      ],
+      "controls": [
+        {
+          "fieldId": "title",
+          "widgetId": "singleLine",
+          "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "author",
+          "widgetId": "entryLinkEditor",
+          "widgetNamespace": "builtin"
+        }
+      ]
+    }
+  ],
+  "entries": [
+    {
+      "metadata": {
+        "tags": [
+        ]
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "id": "5NCD8ztIrVWo7MMBf9f81D",
+        "type": "Entry",
+        "createdAt": "2023-03-21T23:43:44.399Z",
+        "updatedAt": "2023-03-21T23:43:44.399Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "post"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Published page"
+        }
+      }
+    },
+    {
+      "metadata": {
+        "tags": [
+        ]
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "id": "6T4f1JKI3KbeqElChsqUZs",
+        "type": "Entry",
+        "createdAt": "2023-03-21T23:45:03.006Z",
+        "updatedAt": "2023-03-21T23:45:03.006Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "revision": 1,
+        "contentType": {
+          "sys": {
+            "type": "Link",
+            "linkType": "ContentType",
+            "id": "post"
+          }
+        }
+      },
+      "fields": {
+        "title": {
+          "en-US": "Published page with draft person"
+        },
+        "author": {
+          "en-US": {
+            "sys": {
+              "type": "Link",
+              "linkType": "Entry",
+              "id": "9lDgwws6jtn8ow1CkWDmA"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "assets": [
+    {
+      "metadata": {
+        "tags": [
+        ]
+      },
+      "sys": {
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "id": "4S9vZQAr0k7gS37zi7iNDG",
+        "type": "Asset",
+        "createdAt": "2023-02-28T20:32:04.972Z",
+        "updatedAt": "2023-02-28T20:32:04.972Z",
+        "environment": {
+          "sys": {
+            "id": "master",
+            "type": "Link",
+            "linkType": "Environment"
+          }
+        },
+        "revision": 1
+      },
+      "fields": {
+        "title": {
+          "en-US": "Norway"
+        },
+        "description": {
+          "en-US": "A fjord in Norway"
+        },
+        "file": {
+          "en-US": {
+            "url": "//images.ctfassets.net/6cvippge3sd1/4S9vZQAr0k7gS37zi7iNDG/c3c715c652fd3a26f94a032e1a06cf9a/image.png",
+            "details": {
+              "size": 1311262,
+              "image": {
+                "width": 1109,
+                "height": 750
+              }
+            },
+            "fileName": "image.png",
+            "contentType": "image/png"
+          }
+        }
+      }
+    }
+  ],
+  "locales": [
+    {
+      "name": "English (United States)",
+      "code": "en-US",
+      "fallbackCode": null,
+      "default": true,
+      "contentManagementApi": true,
+      "contentDeliveryApi": true,
+      "optional": false,
+      "sys": {
+        "type": "Locale",
+        "id": "2nEMtGrzor8718dMRdtm5D",
+        "version": 1,
+        "space": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Space",
+            "id": "6cvippge3sd1"
+          }
+        },
+        "environment": {
+          "sys": {
+            "type": "Link",
+            "linkType": "Environment",
+            "id": "master",
+            "uuid": "f338763c-b95e-483e-bebb-ca6351c96fff"
+          }
+        },
+        "createdBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "createdAt": "2023-02-23T20:12:22Z",
+        "updatedBy": {
+          "sys": {
+            "type": "Link",
+            "linkType": "User",
+            "id": "2jYeCfa60UhCFs76N2hp6o"
+          }
+        },
+        "updatedAt": "2023-02-23T20:12:22Z"
+      }
+    }
+  ]
+}

--- a/src/test/fixtures/drafts.published.json
+++ b/src/test/fixtures/drafts.published.json
@@ -161,7 +161,7 @@
         "id": "post",
         "type": "ContentType",
         "createdAt": "2023-03-20T20:34:37.761Z",
-        "updatedAt": "2023-03-22T00:03:47.790Z",
+        "updatedAt": "2023-03-23T00:27:59.264Z",
         "environment": {
           "sys": {
             "id": "master",
@@ -169,8 +169,8 @@
             "linkType": "Environment"
           }
         },
-        "publishedVersion": 13,
-        "publishedAt": "2023-03-22T00:03:47.790Z",
+        "publishedVersion": 15,
+        "publishedAt": "2023-03-23T00:27:59.264Z",
         "firstPublishedAt": "2023-03-20T20:34:38.084Z",
         "createdBy": {
           "sys": {
@@ -186,8 +186,8 @@
             "id": "2jYeCfa60UhCFs76N2hp6o"
           }
         },
-        "publishedCounter": 7,
-        "version": 14,
+        "publishedCounter": 8,
+        "version": 16,
         "publishedBy": {
           "sys": {
             "type": "Link",
@@ -222,6 +222,54 @@
           "disabled": false,
           "omitted": false,
           "linkType": "Entry"
+        },
+        {
+          "id": "body",
+          "name": "body",
+          "type": "RichText",
+          "localized": false,
+          "required": false,
+          "validations": [
+            {
+              "enabledMarks": [
+                "bold",
+                "italic",
+                "underline",
+                "code",
+                "superscript",
+                "subscript"
+              ],
+              "message": "Only bold, italic, underline, code, superscript, and subscript marks are allowed"
+            },
+            {
+              "enabledNodeTypes": [
+                "heading-1",
+                "heading-2",
+                "heading-3",
+                "heading-4",
+                "heading-5",
+                "heading-6",
+                "ordered-list",
+                "unordered-list",
+                "hr",
+                "blockquote",
+                "embedded-entry-block",
+                "embedded-asset-block",
+                "table",
+                "entry-hyperlink",
+                "asset-hyperlink",
+                "embedded-entry-inline",
+                "hyperlink"
+              ],
+              "message": "Only heading 1, heading 2, heading 3, heading 4, heading 5, heading 6, ordered list, unordered list, horizontal rule, quote, block entry, asset, table, link to entry, link to asset, inline entry, and link to Url nodes are allowed"
+            },
+            {
+              "nodes": {
+              }
+            }
+          ],
+          "disabled": false,
+          "omitted": false
         }
       ]
     }
@@ -346,7 +394,7 @@
             "linkType": "Space"
           }
         },
-        "version": 14,
+        "version": 16,
         "createdAt": "2023-03-20T20:34:38.187Z",
         "createdBy": {
           "sys": {
@@ -355,7 +403,7 @@
             "linkType": "User"
           }
         },
-        "updatedAt": "2023-03-22T00:03:48.358Z",
+        "updatedAt": "2023-03-23T00:28:00.355Z",
         "updatedBy": {
           "sys": {
             "id": "2jYeCfa60UhCFs76N2hp6o",
@@ -420,98 +468,16 @@
           "fieldId": "author",
           "widgetId": "entryLinkEditor",
           "widgetNamespace": "builtin"
+        },
+        {
+          "fieldId": "body",
+          "widgetId": "richTextEditor",
+          "widgetNamespace": "builtin"
         }
       ]
     }
   ],
   "entries": [
-    {
-      "metadata": {
-        "tags": [
-        ]
-      },
-      "sys": {
-        "space": {
-          "sys": {
-            "type": "Link",
-            "linkType": "Space",
-            "id": "6cvippge3sd1"
-          }
-        },
-        "id": "5NCD8ztIrVWo7MMBf9f81D",
-        "type": "Entry",
-        "createdAt": "2023-03-21T23:43:44.399Z",
-        "updatedAt": "2023-03-21T23:43:44.399Z",
-        "environment": {
-          "sys": {
-            "id": "master",
-            "type": "Link",
-            "linkType": "Environment"
-          }
-        },
-        "revision": 1,
-        "contentType": {
-          "sys": {
-            "type": "Link",
-            "linkType": "ContentType",
-            "id": "post"
-          }
-        }
-      },
-      "fields": {
-        "title": {
-          "en-US": "Published page"
-        }
-      }
-    },
-    {
-      "metadata": {
-        "tags": [
-        ]
-      },
-      "sys": {
-        "space": {
-          "sys": {
-            "type": "Link",
-            "linkType": "Space",
-            "id": "6cvippge3sd1"
-          }
-        },
-        "id": "6T4f1JKI3KbeqElChsqUZs",
-        "type": "Entry",
-        "createdAt": "2023-03-21T23:45:03.006Z",
-        "updatedAt": "2023-03-21T23:45:03.006Z",
-        "environment": {
-          "sys": {
-            "id": "master",
-            "type": "Link",
-            "linkType": "Environment"
-          }
-        },
-        "revision": 1,
-        "contentType": {
-          "sys": {
-            "type": "Link",
-            "linkType": "ContentType",
-            "id": "post"
-          }
-        }
-      },
-      "fields": {
-        "title": {
-          "en-US": "Published page with draft person"
-        },
-        "author": {
-          "en-US": {
-            "sys": {
-              "type": "Link",
-              "linkType": "Entry",
-              "id": "9lDgwws6jtn8ow1CkWDmA"
-            }
-          }
-        }
-      }
-    }
   ],
   "assets": [
     {

--- a/src/test/references.test.ts
+++ b/src/test/references.test.ts
@@ -15,9 +15,10 @@ describe('Reference fields', async () => {
       locale: undefined,
     } as const
 
-    const res = (await contentfulToDataset(data as any, options)).split('\n').map(parse)
+    const res = (await contentfulToDataset({drafts: data as any, published: data as any}, options)).split('\n').map(parse)
     // 1ulybB3BSdHCNQe2UCWbX5 is the id of a post with a broken `author` link
     const post = res.find((e) => e._id === '1ulybB3BSdHCNQe2UCWbX5')
+    expect(post).toBeDefined()
     // NOTE: I would have liked to set this to _weak: true and preserve the
     // intention of a reference, but the import step would attempt to strengthen
     // this _ref according to the schema and that would fail. So the best we can

--- a/src/test/references.test.ts
+++ b/src/test/references.test.ts
@@ -15,7 +15,9 @@ describe('Reference fields', async () => {
       locale: undefined,
     } as const
 
-    const res = (await contentfulToDataset({drafts: data as any, published: data as any}, options)).split('\n').map(parse)
+    const res = (await contentfulToDataset({drafts: data as any, published: data as any}, options))
+      .split('\n')
+      .map(parse)
     // 1ulybB3BSdHCNQe2UCWbX5 is the id of a post with a broken `author` link
     const post = res.find((e) => e._id === '1ulybB3BSdHCNQe2UCWbX5')
     expect(post).toBeDefined()

--- a/src/utils/contentfulEntry.ts
+++ b/src/utils/contentfulEntry.ts
@@ -1,0 +1,13 @@
+import {type EntryProps} from 'contentful-management'
+
+export function isDraft(entry: EntryProps<Record<string, Record<string, any>>>): boolean {
+  return entry.sys.publishedVersion === undefined
+}
+
+export function isChanged(entry: EntryProps<Record<string, Record<string, any>>>): boolean {
+  return !!entry.sys.publishedVersion && entry.sys.version >= entry.sys.publishedVersion + 2
+}
+
+export function isPublished(entry: EntryProps<Record<string, Record<string, any>>>): boolean {
+  return !!entry.sys.publishedVersion && entry.sys.version == entry.sys.publishedVersion + 1
+}

--- a/src/utils/contentfulEntry.ts
+++ b/src/utils/contentfulEntry.ts
@@ -11,3 +11,7 @@ export function isChanged(entry: EntryProps<Record<string, Record<string, any>>>
 export function isPublished(entry: EntryProps<Record<string, Record<string, any>>>): boolean {
   return !!entry.sys.publishedVersion && entry.sys.version == entry.sys.publishedVersion + 1
 }
+
+export function isArchived(entry: EntryProps<Record<string, Record<string, any>>>) {
+  return !!entry.sys.archivedVersion
+}

--- a/src/utils/contentfulEntryToSanityObject.ts
+++ b/src/utils/contentfulEntryToSanityObject.ts
@@ -70,7 +70,7 @@ export function contentfulEntryToSanityObject(
         doc[key] = value
       }
     } else if (objectIsContentfulLink(value)) {
-      doc[key] = contentfulLinkToSanityReference(value, locale, data, options)
+      doc[key] = contentfulLinkToSanityReference(id, value, locale, data, options)
     } else if (objectIsContentfulLocation(value)) {
       doc[key] = {
         _type: 'geopoint',
@@ -79,7 +79,7 @@ export function contentfulEntryToSanityObject(
       }
     } else if (objectIsContentfulRichText(value)) {
       const referenceResolver: ReferenceResolver = (node) =>
-        contentfulLinkToSanityReference(node.data.target, locale, data, options)
+        contentfulLinkToSanityReference(id, node.data.target, locale, data, options)
 
       doc[key] = toPortableText(value, {
         generateKey: () => generateKey(),
@@ -98,7 +98,7 @@ export function contentfulEntryToSanityObject(
       doc[key] = compact(
         value.map((val) => {
           if (objectIsContentfulLink(val)) {
-            return contentfulLinkToSanityReference(val, locale, data, options)
+            return contentfulLinkToSanityReference(id, val, locale, data, options)
           }
 
           return val

--- a/src/utils/contentfulEntryToSanityObject.ts
+++ b/src/utils/contentfulEntryToSanityObject.ts
@@ -28,29 +28,15 @@ type Options = {
   weakRefs?: boolean
 }
 
-function isDraft(entry: EntryProps<Record<string, Record<string, any>>>): boolean {
-  return entry.sys.publishedVersion === undefined
-}
-
-function isChanged(entry: EntryProps<Record<string, Record<string, any>>>): boolean {
-  return !!entry.sys.publishedVersion && entry.sys.version >= entry.sys.publishedVersion + 2
-}
-
-function idForEntry(entry: EntryProps<Record<string, Record<string, any>>>): string {
-  if (isDraft(entry) || isChanged(entry)) {
-    return `drafts.${entry.sys.id}`
-  }
-  return entry.sys.id
-}
-
 export function contentfulEntryToSanityObject(
+  id: string,
   entry: EntryProps<Record<string, Record<string, any>>>,
   locale: string,
   data: ContentfulExport,
   options: Options,
 ): SanityDocument {
   let doc: SanityDocument = {
-    _id: idForEntry(entry),
+    _id: id,
     _rev: entry.sys.id,
     _type: entry.sys.contentType.sys.id,
     _createdAt: entry.sys.createdAt,

--- a/src/utils/contentfulEntryToSanityObject.ts
+++ b/src/utils/contentfulEntryToSanityObject.ts
@@ -28,6 +28,21 @@ type Options = {
   weakRefs?: boolean
 }
 
+function isDraft(entry: EntryProps<Record<string, Record<string, any>>>): boolean {
+  return entry.sys.publishedVersion === undefined
+}
+
+function isChanged(entry: EntryProps<Record<string, Record<string, any>>>): boolean {
+  return !!entry.sys.publishedVersion && entry.sys.version >= entry.sys.publishedVersion + 2
+}
+
+function idForEntry(entry: EntryProps<Record<string, Record<string, any>>>): string {
+  if (isDraft(entry) || isChanged(entry)) {
+    return `drafts.${entry.sys.id}`
+  }
+  return entry.sys.id
+}
+
 export function contentfulEntryToSanityObject(
   entry: EntryProps<Record<string, Record<string, any>>>,
   locale: string,
@@ -35,7 +50,7 @@ export function contentfulEntryToSanityObject(
   options: Options,
 ): SanityDocument {
   let doc: SanityDocument = {
-    _id: entry.sys.id,
+    _id: idForEntry(entry),
     _rev: entry.sys.id,
     _type: entry.sys.contentType.sys.id,
     _createdAt: entry.sys.createdAt,

--- a/src/utils/contentfulLinkToSanityReference.ts
+++ b/src/utils/contentfulLinkToSanityReference.ts
@@ -20,6 +20,7 @@ function prefixUrl(url: string) {
 }
 
 export function contentfulLinkToSanityReference(
+  id: string,
   link: SysLink,
   locale: string,
   data: ContentfulExport,
@@ -63,6 +64,22 @@ export function contentfulLinkToSanityReference(
   }
 
   if (isDraft(linkedEntry)) {
+    if (id.startsWith('drafts.')) {
+      // We allow a draft to link to another draft
+      const type = linkedEntry.sys.contentType.sys.id
+      return {
+        _type: 'reference',
+        _ref: `drafts.${link.sys.id}`,
+        _weak: true,
+        _strengthenOnPublish: {
+          type: type,
+          template: {
+            id: type,
+            params: {},
+          },
+        },
+      }
+    }
     // eslint-disable-next-line no-console
     console.warn(`Link to draft entry with ID [${link.sys.id}]`)
     return null

--- a/src/utils/contentfulLinkToSanityReference.ts
+++ b/src/utils/contentfulLinkToSanityReference.ts
@@ -1,6 +1,7 @@
 import {Reference} from '@sanity/types'
 
 import type {ContentfulExport} from '../types'
+import {isDraft} from './contentfulEntry'
 import type {SysLink} from './objectIsContentfulLink'
 
 type Options = {
@@ -58,6 +59,12 @@ export function contentfulLinkToSanityReference(
   if (!linkedEntry) {
     // eslint-disable-next-line no-console
     console.warn(`Missing entry with ID [${link.sys.id}]`)
+    return null
+  }
+
+  if (isDraft(linkedEntry)) {
+    // eslint-disable-next-line no-console
+    console.warn(`Link to draft entry with ID [${link.sys.id}]`)
     return null
   }
 


### PR DESCRIPTION
This PR adds support for drafts and changed entries. This is achieved by adding an additional content export. The existing export is changed to include drafts, and the additional export is using the content delivery API to only fetch published documents. This ensures that we can migrate drafts, changed and published entities.

This requires a new argument with the access token for the content delivery api